### PR TITLE
test: fix integrationTest stub server thread-safety races

### DIFF
--- a/gateway/app/src/integrationTest/java/dev/feddi/federation/app/DocumentProviderIntegrationTest.java
+++ b/gateway/app/src/integrationTest/java/dev/feddi/federation/app/DocumentProviderIntegrationTest.java
@@ -35,7 +35,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Integration test for the DocumentProvider extension point.
  * Verifies persisted query resolution, unknown hash errors, and fall-through to ParseAndValidate.
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    // See note on YamlIntegrationTest — pin the random port to 127.0.0.1.
+    properties = {"server.address=127.0.0.1"}
+)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Import(DocumentProviderIntegrationTest.TestConfig.class)
 public class DocumentProviderIntegrationTest {

--- a/gateway/app/src/integrationTest/java/dev/feddi/federation/app/GraphQLSubgraphServer.java
+++ b/gateway/app/src/integrationTest/java/dev/feddi/federation/app/GraphQLSubgraphServer.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
 
@@ -74,8 +75,13 @@ public final class GraphQLSubgraphServer {
     private final TypeDefinitionRegistry typeRegistry;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private DisposableServer server;
-    private final List<StubConfiguration> stubs = new ArrayList<>();
-    private final List<RecordedRequest> recordedRequests = new ArrayList<>();
+    // CopyOnWriteArrayList because Reactor Netty dispatches each request on a
+    // separate ctor-http-nio-N thread, and concurrent ArrayList.add() races
+    // produce ArrayIndexOutOfBoundsException ("Index N out of bounds for
+    // length M") that surfaces as a 500 to the calling gateway and shows up
+    // as a flaky cross-subgraph test failure.
+    private final List<StubConfiguration> stubs = new CopyOnWriteArrayList<>();
+    private final List<RecordedRequest> recordedRequests = new CopyOnWriteArrayList<>();
 
     /**
      * Creates a new GraphQL subgraph server.
@@ -328,11 +334,19 @@ public final class GraphQLSubgraphServer {
             @SuppressWarnings("unchecked")
             Map<String, Object> responseData = (Map<String, Object>) stub.response().get("data");
 
-            // Build executable schema with mock data wiring
-            MockDataWiringFactory wiringFactory = new MockDataWiringFactory(responseData);
-            RuntimeWiring wiring = wiringFactory.buildWiring();
-            GraphQLSchema executableSchema = new SchemaGenerator()
-                .makeExecutableSchema(typeRegistry, wiring);
+            // Build executable schema with mock data wiring.
+            // SchemaGenerator.makeExecutableSchema is called against the shared
+            // typeRegistry; GraphQL Java is not documented as thread-safe for
+            // concurrent schema generation off the same registry. Synchronize
+            // to prevent rare concurrent-modification corruption that surfaces
+            // as malformed (text/plain) responses to the calling gateway.
+            GraphQLSchema executableSchema;
+            synchronized (typeRegistry) {
+                MockDataWiringFactory wiringFactory = new MockDataWiringFactory(responseData);
+                RuntimeWiring wiring = wiringFactory.buildWiring();
+                executableSchema = new SchemaGenerator()
+                    .makeExecutableSchema(typeRegistry, wiring);
+            }
 
             GraphQL graphQL = GraphQL.newGraphQL(executableSchema).build();
 

--- a/gateway/app/src/integrationTest/java/dev/feddi/federation/app/GraphQLSubgraphServer.java
+++ b/gateway/app/src/integrationTest/java/dev/feddi/federation/app/GraphQLSubgraphServer.java
@@ -133,20 +133,31 @@ public final class GraphQLSubgraphServer {
         HttpHandler httpHandler = RouterFunctions.toHttpHandler(route);
         ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
 
+        // Bind specifically to 127.0.0.1 (loopback) instead of the wildcard
+        // address. With wildcard, our LISTEN coexists silently with any
+        // other process's specific-address LISTEN on the same port — and
+        // BSD's TCP-listener lookup prefers the more-specific match for
+        // incoming localhost traffic, so client requests to localhost:port
+        // get routed to the *other* process (e.g. an IDE that happens to
+        // bind a port in macOS's ephemeral 49152-65535 range). Binding
+        // specifically to 127.0.0.1 makes the kernel detect the conflict
+        // at bind time as EADDRINUSE; port(0) then skips that port and
+        // assigns a different one.
         server = HttpServer.create()
+            .host("127.0.0.1")
             .port(0)
             .handle(adapter)
             .bindNow();
     }
 
     /**
-     * Returns the base URL of this server (e.g., "http://localhost:54321").
+     * Returns the base URL of this server (e.g., "http://127.0.0.1:54321").
      */
     public String getUrl() {
         if (server == null) {
             throw new IllegalStateException("Server not started");
         }
-        return "http://localhost:" + server.port();
+        return "http://127.0.0.1:" + server.port();
     }
 
     /**

--- a/gateway/app/src/integrationTest/java/dev/feddi/federation/app/HeaderForwardingIntegrationTest.java
+++ b/gateway/app/src/integrationTest/java/dev/feddi/federation/app/HeaderForwardingIntegrationTest.java
@@ -20,7 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Integration test that verifies HTTP headers (Authorization, User-Agent)
  * are forwarded from the gateway to subgraph servers.
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    // See note on YamlIntegrationTest — pin the random port to 127.0.0.1.
+    properties = {"server.address=127.0.0.1"}
+)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class HeaderForwardingIntegrationTest {
 

--- a/gateway/app/src/integrationTest/java/dev/feddi/federation/app/YamlIntegrationTest.java
+++ b/gateway/app/src/integrationTest/java/dev/feddi/federation/app/YamlIntegrationTest.java
@@ -53,7 +53,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *   <li>Stops WireMock servers</li>
  * </ol>
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    // Bind the gateway server to 127.0.0.1 (loopback) rather than the
+    // wildcard so port(0) collisions with other processes' specific-address
+    // LISTEN sockets fail at bind time and the kernel assigns a different
+    // port — see GraphQLSubgraphServer.start() for the full rationale.
+    properties = {"server.address=127.0.0.1"}
+)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class YamlIntegrationTest {
 

--- a/scripts/repro-yaml-it-flake.sh
+++ b/scripts/repro-yaml-it-flake.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# repro-yaml-it-flake.sh — run :gateway:app:integrationTest in a loop to
+# try to reproduce the YamlIntegrationTest @is parallel-lookup flake
+# (is_big_selection / is_type_condition_alternatives) seen in CI.
+#
+# Usage:
+#   scripts/repro-yaml-it-flake.sh [iterations]   # default 30
+#
+# Stops on the first failure and copies the HTML report + log to
+# /tmp/feddi-flake-repro/ for inspection.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+ITERATIONS="${1:-30}"
+
+OUT=/tmp/feddi-flake-repro
+mkdir -p "$OUT"
+echo "Logs and any failed reports → $OUT"
+echo "Running $ITERATIONS iterations of :app:integrationTest"
+
+cd "$PROJECT_ROOT/gateway"
+
+pass=0
+fail=0
+for i in $(seq 1 "$ITERATIONS"); do
+  start=$(date +%s)
+  log="$OUT/iter-${i}.log"
+  if ./gradlew :app:integrationTest --rerun-tasks --console=plain >"$log" 2>&1; then
+    pass=$((pass+1))
+    elapsed=$(( $(date +%s) - start ))
+    echo "[$i/$ITERATIONS] PASS  (${elapsed}s)"
+    rm -f "$log"
+  else
+    fail=$((fail+1))
+    elapsed=$(( $(date +%s) - start ))
+    echo "[$i/$ITERATIONS] FAIL  (${elapsed}s) — log: $log"
+    # Capture the failed run's report
+    rep_src="$PROJECT_ROOT/gateway/app/build/reports/tests/integrationTest"
+    if [[ -d "$rep_src" ]]; then
+      cp -r "$rep_src" "$OUT/iter-${i}-report"
+      echo "  report → $OUT/iter-${i}-report/index.html"
+    fi
+    xml_src="$PROJECT_ROOT/gateway/app/build/test-results/integrationTest"
+    if [[ -d "$xml_src" ]]; then
+      cp -r "$xml_src" "$OUT/iter-${i}-xml"
+    fi
+    break
+  fi
+done
+
+echo ""
+echo "Result: $pass pass / $fail fail (out of $i run)"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
## Background
`YamlIntegrationTest` runs ~322 dynamic tests across many YAML schemas. The gateway dispatches per-entity `@lookup` calls in parallel against a Reactor Netty test stub server (`GraphQLSubgraphServer`). On run [25093161834](https://github.com/feddi-dev/feddi-gateway/actions/runs/25093161834) two `YamlIntegrationTest` cases failed on a commit that only touched README + SVGs — a flake. Local reproduction surfaced ~1-3% flake rate per `:app:integrationTest` run, with rotating symptoms across many test schemas. **Three independent root causes** were untangled.

## Symptoms observed before the fixes
| Mode | Surface |
|---|---|
| 1 | `Subgraph 'X' execution failed: ... Index N out of bounds for length M` |
| 2 | `Content type 'text/plain' not supported for bodyType=java.util.Map<?, ?>` (HTTP 403) |
| 3 | `Content type 'text/html' not supported for bodyType=java.util.Map<?, ?>` (HTTP 404) |
| 4 | `Connection prematurely closed BEFORE response` |
| 5 | `Actual data: {}` — empty response, or one entity has `null` for fields from the failing subgraph |

## Root causes & fixes

### Fix 1 — `recordedRequests` / `stubs` were plain `ArrayList`
Concurrent `ArrayList.add()` from parallel WebFlux handlers races and produces `ArrayIndexOutOfBoundsException("Index N out of bounds for length M")`. The exception is caught by the handler's `catch (Exception e)` and returned to the gateway as 500 with that message — directly the **Mode 1** symptom. Switched both lists to `CopyOnWriteArrayList`.

### Fix 2 — `SchemaGenerator.makeExecutableSchema(typeRegistry, ...)` against a shared registry
`typeRegistry` is constructed once per server and reused. GraphQL Java is not documented as safe for concurrent schema generation off the same `TypeDefinitionRegistry`. Wrapped the schema-generation block in `synchronized (typeRegistry)`. Per-request `graphQL.execute()` remains parallel.

### Fix 3 — Test sockets bound to wildcard collided with other processes' loopback LISTEN sockets
The flake's most stubborn surface (Modes 2-4) was port collision, but the diagnosis took several iterations:

**First (wrong) hypothesis** — that the build daemon's test-worker control-socket *source* port collided with our `port(0)` LISTEN bind. Theory was internally consistent but **wrong**.

**Actual cause** — confirmed empirically with `lsof -nP -iTCP -sTCP:LISTEN`: other unrelated local processes (developer-machine background services — IDEs, debuggers, the build daemon's own listener, etc.) had **specific-address** LISTEN sockets on `127.0.0.1` in macOS's ephemeral range (49152-65535). When our test JVM does `port(0)`, the kernel happily hands us the same port — wildcard LISTEN and specific-address LISTEN are explicitly allowed to coexist on the same port. But for incoming `localhost:port` traffic, the kernel's listener lookup **prefers the more-specific match**, so client requests get routed to the *other* process. That process either:
- returns `404 NOT_FOUND` with `text/html` (it doesn't serve HTTP for that path)
- returns `403 FORBIDDEN` with `text/plain` (similar)
- reads HTTP bytes as some other binary protocol and discards them

**Fix**: bind our test sockets specifically to `127.0.0.1` instead of the wildcard:
- `GraphQLSubgraphServer` — `HttpServer.create().host("127.0.0.1").port(0)`
- `@SpringBootTest` gateways — `properties = {"server.address=127.0.0.1"}`

This makes the kernel detect the conflict at bind time as `EADDRINUSE`; `port(0)` then skips that port and assigns a different one. No coexistence, no routing ambiguity.

(Initial attempt was to pin to 18100-19099 to avoid the ephemeral range entirely. The loopback-bind approach is cleaner — no hardcoded range, no manual probe, kernel handles allocation.)

## Validation
| State | YAML iters before flake |
|---|---|
| Unfixed | ~30-50 |
| + Fix 1 (CoWAL) | ~50-100 |
| + Fix 1 + Fix 2 (synchronized) | ~95-150 |
| + Fix 1 + Fix 2 + Fix 3 (port-pinning, earlier attempt) | 200/200 clean |
| + Fix 1 + Fix 2 + Fix 3 (loopback bind, this PR) | full suite 1462/1462 ✅ |

Final validation: `scripts/run-all-tests.sh` — **1462/1462** tests pass:
- `gateway/engine` (unit): 1099
- `gateway/app` (unit): 10
- **`gateway/app` (integration): 322**
- `e2e-tests` (Testcontainers): 31

## Repro tool
`scripts/repro-yaml-it-flake.sh [iterations]` (default 30) runs `:app:integrationTest --rerun-tasks` in a loop and stops on the first failure, copying the JUnit XML and HTML report to `/tmp/feddi-flake-repro/iter-N-{xml,report}/` and the gradle log to `/tmp/feddi-flake-repro/iter-N.log`.

## Test plan
- [x] `compileIntegrationTestJava` passes
- [x] Single iteration of `:app:integrationTest` passes
- [x] Full `scripts/run-all-tests.sh`: **1462/1462** pass
- [ ] CI `Test` workflow on this PR is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)