### PR TITLE
Ignore copied gateway E2E app jar

### DIFF
--- a/e2e-tests/.gitignore
+++ b/e2e-tests/.gitignore
@@ -6,6 +6,7 @@ build
 
 # Ignore copied feddi Gateway JAR (build artifact)
 docker/feddi-gateway/*.jar
+docker/gateway/*.jar
 
 # Ignore copied extensions JARs (build artifacts)
 docker/feddi-gateway/libs/


### PR DESCRIPTION
## Summary
- ignore copied gateway E2E app JAR artifacts under e2e-tests/docker/gateway

## Testing
- verified e2e-tests/docker/gateway/app.jar is ignored with git check-ignore