### PR TITLE
Align GraphQL Java version with API usage client

### DIFF
--- a/gateway/gradle/libs.versions.toml
+++ b/gateway/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-graphql-java = "0.0.0-2026-05-10T11-05-39-cb6c245"
+graphql-java = "0.0.0-2026-05-12T01-33-43-16153d0"
 reactor = "3.8.2"
 antlr = "4.13.2"
 jackson = "2.21.0"


### PR DESCRIPTION
Updates the gateway's canonical GraphQL Java version to the newer API usage client version: 0.0.0-2026-05-12T01-33-43-16153d0.

The feddi-repo repository consistency checks will use this gateway catalog value as the canonical version across backend, gateway, API usage client, platform extensions, gateway E2E, and load-testing builds.