### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,73 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "gradle"
+    directory: "/gateway"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "gradle"
+    directory: "/e2e-tests"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "npm"
+    directory: "/e2e-tests/docker/subgraphs/products"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+
+  - package-ecosystem: "npm"
+    directory: "/e2e-tests/docker/subgraphs/reviews"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+
+  - package-ecosystem: "docker"
+    directory: "/gateway/app"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/e2e-tests/docker/feddi-gateway"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/e2e-tests/docker/subgraphs/products"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/e2e-tests/docker/subgraphs/reviews"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "docker-compose"
+    directory: "/e2e-tests/docker"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- add Dependabot version updates for GitHub Actions, Gradle, npm, Docker, and Docker Compose
- set a 7-day cooldown for all update entries
- set a stricter 14-day cooldown for npm major version updates

## Validation
- parsed dependabot.yml and verified all entries have cooldown.default-days = 7
- verified npm entries have cooldown.semver-major-days = 14