### PR TITLE
Add test baseline reporting

### DIFF
--- a/.github/scripts/parse-jacoco.js
+++ b/.github/scripts/parse-jacoco.js
@@ -1,0 +1,115 @@
+const fs = require('fs');
+
+const zeroCov = { covered: 0, missed: 0 };
+
+function parseJacocoXml(jacocoFile) {
+  const result = { overall: {}, classes: {} };
+
+  if (!fs.existsSync(jacocoFile)) {
+    return null;
+  }
+
+  const xml = fs.readFileSync(jacocoFile, 'utf8');
+
+  const stripped = xml.replace(/<package[\s\S]*?<\/package>/g, '');
+  const counterRe = /<counter type="(\w+)" missed="(\d+)" covered="(\d+)"\/>/g;
+  let counterMatch;
+  while ((counterMatch = counterRe.exec(stripped)) !== null) {
+    const entry = {
+      covered: parseInt(counterMatch[3], 10),
+      missed: parseInt(counterMatch[2], 10),
+    };
+    if (counterMatch[1] === 'LINE') result.overall.line = entry;
+    else if (counterMatch[1] === 'BRANCH') result.overall.branch = entry;
+    else if (counterMatch[1] === 'METHOD') result.overall.method = entry;
+  }
+
+  const packageRe = /<package\s+name="([^"]+)">([\s\S]*?)<\/package>/g;
+  let packageMatch;
+  while ((packageMatch = packageRe.exec(xml)) !== null) {
+    const classRe = /<class\s+name="([^"]+)"[^>]*(?<!\/)>([\s\S]*?)<\/class>/g;
+    let classMatch;
+    while ((classMatch = classRe.exec(packageMatch[2])) !== null) {
+      const className = classMatch[1].replace(/\//g, '.');
+      const classBody = classMatch[2];
+      const counters = {
+        line: { ...zeroCov },
+        branch: { ...zeroCov },
+        method: { ...zeroCov },
+      };
+
+      const classCounterRe = /<counter type="(\w+)" missed="(\d+)" covered="(\d+)"\/>/g;
+      let classCounterMatch;
+      while ((classCounterMatch = classCounterRe.exec(classBody)) !== null) {
+        const entry = {
+          covered: parseInt(classCounterMatch[3], 10),
+          missed: parseInt(classCounterMatch[2], 10),
+        };
+        if (classCounterMatch[1] === 'LINE') counters.line = entry;
+        else if (classCounterMatch[1] === 'BRANCH') counters.branch = entry;
+        else if (classCounterMatch[1] === 'METHOD') counters.method = entry;
+      }
+
+      const methods = [];
+      const methodRe = /<method\s+name="([^"]+)"\s+desc="([^"]+)"(?:\s+line="(\d+)")?[^>]*>([\s\S]*?)<\/method>/g;
+      let methodMatch;
+      while ((methodMatch = methodRe.exec(classBody)) !== null) {
+        const methodCounters = {
+          line: { ...zeroCov },
+          branch: { ...zeroCov },
+          method: { ...zeroCov },
+        };
+        const methodCounterRe = /<counter type="(\w+)" missed="(\d+)" covered="(\d+)"\/>/g;
+        let methodCounterMatch;
+        while ((methodCounterMatch = methodCounterRe.exec(methodMatch[4])) !== null) {
+          const entry = {
+            covered: parseInt(methodCounterMatch[3], 10),
+            missed: parseInt(methodCounterMatch[2], 10),
+          };
+          if (methodCounterMatch[1] === 'LINE') methodCounters.line = entry;
+          else if (methodCounterMatch[1] === 'BRANCH') methodCounters.branch = entry;
+          else if (methodCounterMatch[1] === 'METHOD') methodCounters.method = entry;
+        }
+
+        if (methodCounters.line.covered + methodCounters.line.missed > 0) {
+          methods.push({
+            name: methodMatch[1],
+            desc: methodMatch[2],
+            line: methodMatch[3] ? parseInt(methodMatch[3], 10) : null,
+            counters: methodCounters,
+          });
+        }
+      }
+
+      if (counters.line.covered + counters.line.missed > 0) {
+        result.classes[className] = counters;
+        if (methods.length > 0) {
+          result.classes[className].methods = methods;
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+function pct(covered, missed) {
+  const total = covered + missed;
+  return total === 0 ? 0 : (covered / total) * 100;
+}
+
+function counterPct(counter) {
+  return pct(counter?.covered || 0, counter?.missed || 0);
+}
+
+function isRegression(currPct, basePct, currMissed, baseMissed, tolerance = 0.05) {
+  return currPct < basePct - tolerance && currMissed > baseMissed;
+}
+
+module.exports = {
+  parseJacocoXml,
+  pct,
+  counterPct,
+  zeroCov,
+  isRegression,
+};

--- a/.github/scripts/test-report.js
+++ b/.github/scripts/test-report.js
@@ -1,0 +1,516 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const childProcess = require('child_process');
+const {
+  parseJacocoXml,
+  pct,
+  counterPct,
+  zeroCov,
+  isRegression,
+} = require('./parse-jacoco.js');
+
+const markerStart = '<!-- test-results-start -->';
+const markerEnd = '<!-- test-results-end -->';
+const zeroTest = { total: 0, passed: 0, failed: 0, errors: 0, skipped: 0 };
+
+const testSuites = [
+  { key: 'gateway-engine', label: 'Gateway engine', results: 'gateway/engine/build/test-results/test' },
+  { key: 'gateway-app-unit', label: 'Gateway app unit', results: 'gateway/app/build/test-results/test' },
+  { key: 'gateway-app-integration', label: 'Gateway app integration', results: 'gateway/app/build/test-results/integrationTest' },
+  { key: 'e2e-tests', label: 'E2E tests', results: 'e2e-tests/build/test-results/test' },
+];
+
+const testCategories = [
+  { key: 'composition-success', label: 'Composition success' },
+  { key: 'composition-errors', label: 'Composition errors' },
+  { key: 'planning', label: 'Planning' },
+  { key: 'execution', label: 'Execution' },
+  { key: 'engine-other', label: 'Engine other' },
+];
+
+function usage() {
+  console.error(`Usage:
+  node .github/scripts/test-report.js collect --output <file>
+  node .github/scripts/test-report.js baseline --stats <file> --coverage <file> --baseline <file>
+  node .github/scripts/test-report.js readme --baseline <file> --readme <file>
+  node .github/scripts/test-report.js comment --stats <file> --baseline <file> --coverage <file> --output <file>
+  node .github/scripts/test-report.js gate --baseline <file> --coverage <file>
+  node .github/scripts/test-report.js verify-generated --base-ref <ref>`);
+}
+
+function argValue(args, name, fallback = null) {
+  const index = args.indexOf(name);
+  if (index === -1) return fallback;
+  if (index + 1 >= args.length) {
+    throw new Error(`Missing value for ${name}`);
+  }
+  return args[index + 1];
+}
+
+function ensureParentDir(file) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+}
+
+function readJson(file, fallback) {
+  if (!fs.existsSync(file)) return fallback;
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function writeJson(file, data) {
+  ensureParentDir(file);
+  fs.writeFileSync(file, JSON.stringify(data, null, 2) + '\n');
+}
+
+function listFilesRecursive(dir, predicate = () => true) {
+  if (!fs.existsSync(dir)) return [];
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listFilesRecursive(fullPath, predicate));
+    } else if (predicate(fullPath)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function parseXmlAttributes(tag) {
+  const attrs = {};
+  const attrRe = /([A-Za-z_:][-A-Za-z0-9_:.]*)="([^"]*)"/g;
+  let match;
+  while ((match = attrRe.exec(tag)) !== null) {
+    attrs[match[1]] = match[2];
+  }
+  return attrs;
+}
+
+function parseJunitResults(resultsPath) {
+  const stats = { ...zeroTest };
+  const files = fs.existsSync(resultsPath) && fs.statSync(resultsPath).isFile()
+    ? [resultsPath]
+    : listFilesRecursive(resultsPath, file => path.basename(file).startsWith('TEST-') && file.endsWith('.xml'));
+
+  for (const file of files) {
+    const xml = fs.readFileSync(file, 'utf8');
+    const suiteMatch = xml.match(/<testsuite\b[^>]*>/);
+    if (!suiteMatch) continue;
+    const attrs = parseXmlAttributes(suiteMatch[0]);
+    const total = parseInt(attrs.tests || '0', 10);
+    const failed = parseInt(attrs.failures || '0', 10);
+    const errors = parseInt(attrs.errors || '0', 10);
+    const skipped = parseInt(attrs.skipped || '0', 10);
+    stats.total += total;
+    stats.failed += failed;
+    stats.errors += errors;
+    stats.skipped += skipped;
+  }
+
+  stats.passed = Math.max(0, stats.total - stats.failed - stats.errors - stats.skipped);
+  return stats;
+}
+
+function countYamlFiles(dir) {
+  return listFilesRecursive(dir, file => file.endsWith('.yaml') || file.endsWith('.yml')).length;
+}
+
+function countSchemaCaseFiles(resourcesDir, childDir) {
+  const schemasDir = path.join(resourcesDir, 'schemas');
+  if (!fs.existsSync(schemasDir)) return 0;
+  let total = 0;
+  for (const entry of fs.readdirSync(schemasDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    total += countYamlFiles(path.join(schemasDir, entry.name, childDir));
+  }
+  return total;
+}
+
+function collectTestStats(repoRoot = process.cwd()) {
+  const tests = {};
+  for (const suite of testSuites) {
+    tests[suite.key] = parseJunitResults(path.join(repoRoot, suite.results));
+  }
+
+  const resourcesDir = path.join(repoRoot, 'gateway/engine/src/test/resources');
+  const compositionSuccess = countYamlFiles(path.join(resourcesDir, 'composition/success'));
+  const compositionErrors = countYamlFiles(path.join(resourcesDir, 'composition/errors'));
+  const planning = countSchemaCaseFiles(resourcesDir, 'planning');
+  const execution = countSchemaCaseFiles(resourcesDir, 'executions');
+  const yamlDrivenTotal = compositionSuccess + compositionErrors + planning + execution;
+  const engineOther = Math.max(0, tests['gateway-engine'].total - yamlDrivenTotal);
+
+  const categories = {
+    'composition-success': { total: compositionSuccess },
+    'composition-errors': { total: compositionErrors },
+    planning: { total: planning },
+    execution: { total: execution },
+    'engine-other': { total: engineOther },
+  };
+
+  return { tests, categories };
+}
+
+function statusLabel(stats) {
+  const total = stats?.total || 0;
+  const failed = (stats?.failed || 0) + (stats?.errors || 0);
+  const skipped = stats?.skipped || 0;
+  if (total === 0) return '-';
+  if (failed > 0) return 'fail';
+  if (skipped > 0) return 'skip';
+  return 'pass';
+}
+
+function num(value) {
+  return Number.isFinite(Number(value)) ? Number(value) : 0;
+}
+
+function valueOrDash(value) {
+  return num(value) === 0 ? '-' : String(value);
+}
+
+function delta(curr, base) {
+  const d = num(curr) - num(base);
+  if (d === 0) return '+0';
+  return d > 0 ? `+${d}` : String(d);
+}
+
+function cellWithDelta(curr, base) {
+  return `${num(curr)} (${delta(curr, base)})`;
+}
+
+function formatPct(value) {
+  return `${value.toFixed(1)}%`;
+}
+
+function coverageCounts(counter) {
+  const covered = counter?.covered || 0;
+  const missed = counter?.missed || 0;
+  const total = covered + missed;
+  return total === 0 ? '-' : `${covered}/${total}`;
+}
+
+function coveragePct(counter) {
+  const covered = counter?.covered || 0;
+  const missed = counter?.missed || 0;
+  const total = covered + missed;
+  return total === 0 ? '-' : formatPct(pct(covered, missed));
+}
+
+function coveragePctDelta(curr, base) {
+  const currPct = counterPct(curr || zeroCov);
+  const basePct = counterPct(base || zeroCov);
+  const d = currPct - basePct;
+  if (Math.abs(d) < 0.05) return '+0.0%';
+  return d > 0 ? `+${d.toFixed(1)}%` : `${d.toFixed(1)}%`;
+}
+
+function hasBaselineData(baseline) {
+  return Object.keys(baseline?.tests || {}).length > 0 ||
+    Object.keys(baseline?.categories || {}).length > 0 ||
+    Object.keys(baseline?.coverage?.overall || {}).length > 0;
+}
+
+function buildReadmeSection(baseline) {
+  if (!hasBaselineData(baseline)) {
+    return 'Baseline test results are populated automatically after the next successful `main` build.';
+  }
+
+  const tests = baseline.tests || {};
+  const categories = baseline.categories || {};
+  const coverage = baseline.coverage?.overall || {};
+  const lines = [];
+
+  lines.push('### Test Results');
+  lines.push('| Suite | Tests | Passed | Failed | Errors | Skipped | Status |');
+  lines.push('|:------|------:|-------:|-------:|-------:|--------:|:-------|');
+  for (const suite of testSuites) {
+    const stats = tests[suite.key] || zeroTest;
+    lines.push(`| ${suite.label} | ${valueOrDash(stats.total)} | ${valueOrDash(stats.passed)} | ${valueOrDash(stats.failed)} | ${valueOrDash(stats.errors)} | ${valueOrDash(stats.skipped)} | ${statusLabel(stats)} |`);
+  }
+
+  lines.push('');
+  lines.push('### Test Categories');
+  lines.push('| Category | Count |');
+  lines.push('|:---------|------:|');
+  for (const category of testCategories) {
+    const stats = categories[category.key] || { total: 0 };
+    lines.push(`| ${category.label} | ${valueOrDash(stats.total)} |`);
+  }
+
+  lines.push('');
+  lines.push('### Code Coverage');
+  lines.push('| Metric | Coverage | Covered / Total |');
+  lines.push('|:-------|---------:|----------------:|');
+  for (const { label, key } of [
+    { label: 'Line', key: 'line' },
+    { label: 'Branch', key: 'branch' },
+    { label: 'Method', key: 'method' },
+  ]) {
+    lines.push(`| ${label} | ${coveragePct(coverage[key])} | ${coverageCounts(coverage[key])} |`);
+  }
+
+  return lines.join('\n');
+}
+
+function replaceMarkedSection(content, section) {
+  const start = content.indexOf(markerStart);
+  const end = content.indexOf(markerEnd);
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(`README.md must contain ${markerStart} and ${markerEnd}`);
+  }
+
+  const before = content.slice(0, start + markerStart.length);
+  const after = content.slice(end);
+  return `${before}\n${section}\n${after}`;
+}
+
+function updateReadmeFromBaseline({ baselineFile, readmeFile }) {
+  const baseline = readJson(baselineFile, { tests: {}, categories: {}, coverage: {} });
+  const content = fs.readFileSync(readmeFile, 'utf8');
+  fs.writeFileSync(readmeFile, replaceMarkedSection(content, buildReadmeSection(baseline)));
+}
+
+function updateBaseline({ statsFile, coverageFile, baselineFile }) {
+  const current = readJson(baselineFile, { tests: {}, categories: {}, coverage: { overall: {}, classes: {} } });
+  const stats = readJson(statsFile, { tests: {}, categories: {} });
+  const parsedCoverage = parseJacocoXml(coverageFile);
+  const coverage = parsedCoverage || current.coverage || { overall: {}, classes: {} };
+  writeJson(baselineFile, {
+    tests: stats.tests || {},
+    categories: stats.categories || {},
+    coverage,
+  });
+}
+
+function buildCommentBody({ statsFile, baselineFile, coverageFile }) {
+  const current = readJson(statsFile, { tests: {}, categories: {} });
+  const baseline = readJson(baselineFile, { tests: {}, categories: {}, coverage: {} });
+  const currentCoverage = parseJacocoXml(coverageFile)?.overall || {};
+  const baselineCoverage = baseline.coverage?.overall || {};
+  const now = new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
+  const lines = [];
+
+  lines.push('<!-- test-report -->');
+  lines.push('## Test Report');
+  lines.push('');
+  lines.push('### Test Results');
+  lines.push('| Suite | Total | Passed | Failed | Errors | Skipped |');
+  lines.push('|:------|------:|-------:|-------:|-------:|--------:|');
+  for (const suite of testSuites) {
+    const curr = current.tests?.[suite.key] || zeroTest;
+    const base = baseline.tests?.[suite.key] || zeroTest;
+    lines.push(`| ${suite.label} | ${cellWithDelta(curr.total, base.total)} | ${cellWithDelta(curr.passed, base.passed)} | ${cellWithDelta(curr.failed, base.failed)} | ${cellWithDelta(curr.errors, base.errors)} | ${cellWithDelta(curr.skipped, base.skipped)} |`);
+  }
+
+  lines.push('');
+  lines.push('### Test Categories');
+  lines.push('| Category | Count |');
+  lines.push('|:---------|------:|');
+  for (const category of testCategories) {
+    const curr = current.categories?.[category.key] || { total: 0 };
+    const base = baseline.categories?.[category.key] || { total: 0 };
+    lines.push(`| ${category.label} | ${cellWithDelta(curr.total, base.total)} |`);
+  }
+
+  lines.push('');
+  lines.push('### Code Coverage');
+  if (Object.keys(currentCoverage).length === 0) {
+    lines.push('Coverage report not available.');
+  } else {
+    lines.push('| Metric | Covered | Missed | Coverage | vs Main |');
+    lines.push('|:-------|--------:|-------:|---------:|--------:|');
+    for (const { label, key } of [
+      { label: 'Lines', key: 'line' },
+      { label: 'Branches', key: 'branch' },
+      { label: 'Methods', key: 'method' },
+    ]) {
+      const curr = currentCoverage[key] || zeroCov;
+      const base = baselineCoverage[key] || zeroCov;
+      lines.push(`| ${label} | ${curr.covered} | ${curr.missed} | ${coveragePct(curr)} | ${coveragePctDelta(curr, base)} |`);
+    }
+  }
+
+  lines.push('');
+  lines.push(`> Updated: ${now}`);
+  return lines.join('\n') + '\n';
+}
+
+function formatMethodName(name) {
+  if (name === '&lt;init&gt;' || name === '<init>') return 'constructor';
+  if (name === '&lt;clinit&gt;' || name === '<clinit>') return 'static initializer';
+  return name;
+}
+
+function coverageGate({ baselineFile, coverageFile }) {
+  const baseline = readJson(baselineFile, { coverage: {} });
+  const baseClasses = baseline.coverage?.classes || {};
+  const parsed = parseJacocoXml(coverageFile);
+
+  if (!parsed) {
+    if (Object.keys(baseClasses).length === 0) {
+      console.log('No JaCoCo report or baseline found; skipping coverage gate.');
+      return;
+    }
+    throw new Error(`No JaCoCo report found at ${coverageFile}`);
+  }
+
+  if (Object.keys(baseClasses).length === 0) {
+    console.log('No baseline coverage classes found; skipping coverage gate.');
+    return;
+  }
+
+  const regressions = [];
+  for (const [className, curr] of Object.entries(parsed.classes || {})) {
+    const base = baseClasses[className] || { line: zeroCov, branch: zeroCov, method: zeroCov, methods: [] };
+    const classRegressions = [];
+
+    for (const { label, key } of [
+      { label: 'Line', key: 'line' },
+      { label: 'Branch', key: 'branch' },
+      { label: 'Method', key: 'method' },
+    ]) {
+      const currCounter = curr[key] || zeroCov;
+      const baseCounter = base[key] || zeroCov;
+      const currPct = pct(currCounter.covered, currCounter.missed);
+      const basePct = pct(baseCounter.covered, baseCounter.missed);
+      if (isRegression(currPct, basePct, currCounter.missed, baseCounter.missed)) {
+        classRegressions.push(`  ${className} ${label}: ${currPct.toFixed(1)}% was ${basePct.toFixed(1)}%, missed ${currCounter.missed} was ${baseCounter.missed}`);
+      }
+    }
+
+    if (classRegressions.length === 0) continue;
+    regressions.push(...classRegressions);
+
+    const currMethods = curr.methods || [];
+    const baseMethods = base.methods || [];
+    const baseByKey = {};
+    for (const method of baseMethods) {
+      baseByKey[method.name + method.desc] = method;
+    }
+
+    for (const method of currMethods) {
+      const baseMethod = baseByKey[method.name + method.desc];
+      if (!baseMethod) continue;
+      const currLine = method.counters?.line || zeroCov;
+      const baseLine = baseMethod.counters?.line || zeroCov;
+      const currLinePct = pct(currLine.covered, currLine.missed);
+      const baseLinePct = pct(baseLine.covered, baseLine.missed);
+      if (isRegression(currLinePct, baseLinePct, currLine.missed, baseLine.missed)) {
+        regressions.push(`      ${formatMethodName(method.name)}: ${currLinePct.toFixed(1)}% was ${baseLinePct.toFixed(1)}%, missed ${currLine.missed} was ${baseLine.missed}`);
+      }
+    }
+  }
+
+  if (regressions.length > 0) {
+    throw new Error(`Per-class coverage regressions detected:\n${regressions.join('\n')}`);
+  }
+
+  console.log('No per-class coverage regressions detected.');
+}
+
+function git(args) {
+  return childProcess.execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function gitObjectExists(refPath) {
+  try {
+    git(['cat-file', '-e', refPath]);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+function extractMarkedSection(content) {
+  const start = content.indexOf(markerStart);
+  const end = content.indexOf(markerEnd);
+  if (start === -1 || end === -1 || end < start) return null;
+  return content.slice(start, end + markerEnd.length);
+}
+
+function verifyGeneratedFiles(baseRef) {
+  if (!gitObjectExists(`${baseRef}:test-baseline.json`)) {
+    console.log('No baseline exists on the base branch yet; generated-file guard is in bootstrap mode.');
+    return;
+  }
+
+  const baselineDiff = git(['diff', '--name-only', `${baseRef}...HEAD`, '--', 'test-baseline.json']);
+  if (baselineDiff) {
+    throw new Error('test-baseline.json is generated from main builds and must not be changed directly in PRs.');
+  }
+
+  if (!gitObjectExists(`${baseRef}:README.md`) || !fs.existsSync('README.md')) {
+    return;
+  }
+
+  const baseReadme = git(['show', `${baseRef}:README.md`]);
+  const currentReadme = fs.readFileSync('README.md', 'utf8');
+  const baseSection = extractMarkedSection(baseReadme);
+  const currentSection = extractMarkedSection(currentReadme);
+  if (baseSection && currentSection && baseSection !== currentSection) {
+    throw new Error('The generated README test report section must not be changed directly in PRs.');
+  }
+}
+
+function main() {
+  const [command, ...args] = process.argv.slice(2);
+
+  try {
+    if (command === 'collect') {
+      const output = argValue(args, '--output');
+      if (!output) throw new Error('Missing --output');
+      writeJson(output, collectTestStats(process.cwd()));
+    } else if (command === 'baseline') {
+      updateBaseline({
+        statsFile: argValue(args, '--stats'),
+        coverageFile: argValue(args, '--coverage'),
+        baselineFile: argValue(args, '--baseline'),
+      });
+    } else if (command === 'readme') {
+      updateReadmeFromBaseline({
+        baselineFile: argValue(args, '--baseline'),
+        readmeFile: argValue(args, '--readme'),
+      });
+    } else if (command === 'comment') {
+      const output = argValue(args, '--output');
+      if (!output) throw new Error('Missing --output');
+      ensureParentDir(output);
+      fs.writeFileSync(output, buildCommentBody({
+        statsFile: argValue(args, '--stats'),
+        baselineFile: argValue(args, '--baseline'),
+        coverageFile: argValue(args, '--coverage'),
+      }));
+    } else if (command === 'gate') {
+      coverageGate({
+        baselineFile: argValue(args, '--baseline'),
+        coverageFile: argValue(args, '--coverage'),
+      });
+    } else if (command === 'verify-generated') {
+      verifyGeneratedFiles(argValue(args, '--base-ref', 'origin/main'));
+    } else {
+      usage();
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  buildCommentBody,
+  buildReadmeSection,
+  collectTestStats,
+  coverageGate,
+  parseJunitResults,
+  replaceMarkedSection,
+  updateBaseline,
+  updateReadmeFromBaseline,
+  verifyGeneratedFiles,
+};

--- a/.github/scripts/test-report.test.js
+++ b/.github/scripts/test-report.test.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { isRegression } = require('./parse-jacoco.js');
+const {
+  parseJunitResults,
+  replaceMarkedSection,
+} = require('./test-report.js');
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'test-report-'));
+
+try {
+  const resultsDir = path.join(tmp, 'results');
+  fs.mkdirSync(resultsDir, { recursive: true });
+  fs.writeFileSync(path.join(resultsDir, 'TEST-one.xml'), '<testsuite tests="3" failures="1" errors="0" skipped="1"></testsuite>');
+  fs.writeFileSync(path.join(resultsDir, 'TEST-two.xml'), '<testsuite tests="2" failures="0" errors="1" skipped="0"></testsuite>');
+
+  assert.deepStrictEqual(parseJunitResults(resultsDir), {
+    total: 5,
+    passed: 2,
+    failed: 1,
+    errors: 1,
+    skipped: 1,
+  });
+
+  assert.strictEqual(
+    replaceMarkedSection('before\n<!-- test-results-start -->\nold\n<!-- test-results-end -->\nafter', 'new'),
+    'before\n<!-- test-results-start -->\nnew\n<!-- test-results-end -->\nafter'
+  );
+
+  assert.strictEqual(isRegression(79.9, 80, 11, 10), true);
+  assert.strictEqual(isRegression(79.9, 80, 10, 10), false);
+  assert.strictEqual(isRegression(79.99, 80, 11, 10), false);
+} finally {
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log('test-report helpers passed');

--- a/.github/workflows/pr-test-report.yml
+++ b/.github/workflows/pr-test-report.yml
@@ -1,0 +1,96 @@
+name: PR Test Report
+
+on:
+  workflow_run:
+    workflows: [ "Test" ]
+    types: [ completed ]
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  post-report:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.conclusion == 'success' ||
+       github.event.workflow_run.conclusion == 'failure')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+
+      - name: Download test stats
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: test-stats
+          path: test-stats
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: coverage-report
+          path: coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate comment body
+        run: node .github/scripts/test-report.js comment --stats test-stats/test-stats.json --baseline test-baseline.json --coverage coverage/jacocoAggregateReport.xml --output comment.md
+
+      - name: Upsert PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            let prNumber = (context.payload.workflow_run.pull_requests || [])[0]?.number;
+            if (!prNumber) {
+              const headBranch = context.payload.workflow_run.head_branch;
+              const headOwner = context.payload.workflow_run.head_repository.owner.login;
+              const { data: prs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head: `${headOwner}:${headBranch}`,
+                state: 'open',
+              });
+              if (prs.length > 0) {
+                prNumber = prs[0].number;
+              }
+            }
+
+            if (!prNumber) {
+              console.log('No pull request associated with this workflow run, skipping.');
+              return;
+            }
+
+            const body = fs.readFileSync('comment.md', 'utf8');
+            const marker = '<!-- test-report -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(comment => comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -13,6 +18,20 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Fetch main for generated file guard
+        if: github.event_name == 'pull_request'
+        run: git fetch origin main --depth=1
+
+      - name: Verify generated files are not updated in PRs
+        if: github.event_name == 'pull_request'
+        run: node .github/scripts/test-report.js verify-generated --base-ref origin/main
+
+      - name: Prepare main baseline for PR checks
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir -p baseline-main
+          git show origin/main:test-baseline.json > baseline-main/test-baseline.json 2>/dev/null || cp test-baseline.json baseline-main/test-baseline.json
 
       - name: Set up Java 25
         uses: actions/setup-java@v4
@@ -26,6 +45,44 @@ jobs:
       - name: Run tests
         run: ./scripts/run-all-tests.sh
 
+      - name: Collect test stats
+        if: always()
+        run: node .github/scripts/test-report.js collect --output test-stats/test-stats.json
+
+      - name: Run report helper tests
+        run: node .github/scripts/test-report.test.js
+
+      - name: Enforce per-class coverage gate
+        if: always() && github.event_name == 'pull_request'
+        run: node .github/scripts/test-report.js gate --baseline baseline-main/test-baseline.json --coverage gateway/build/reports/jacoco/jacocoAggregateReport/jacocoAggregateReport.xml
+
+      - name: Upload test stats
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-stats
+          path: test-stats/test-stats.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload coverage XML report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: gateway/build/reports/jacoco/jacocoAggregateReport/jacocoAggregateReport.xml
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload coverage HTML report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-html-report
+          path: gateway/build/reports/jacoco/jacocoAggregateReport/html/
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
@@ -37,3 +94,43 @@ jobs:
             e2e-tests/**/build/reports/tests/
             e2e-tests/**/build/test-results/
           retention-days: 7
+
+  publish-results:
+    name: Publish Test Baseline
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          ssh-key: ${{ secrets.BASELINE_DEPLOY_KEY }}
+
+      - name: Download test stats
+        uses: actions/download-artifact@v4
+        with:
+          name: test-stats
+          path: test-stats
+
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage
+
+      - name: Update test baseline
+        run: node .github/scripts/test-report.js baseline --stats test-stats/test-stats.json --coverage coverage/jacocoAggregateReport.xml --baseline test-baseline.json
+
+      - name: Update README test report
+        run: node scripts/generate-readme-test-report.js
+
+      - name: Push updated baseline and README
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add test-baseline.json README.md
+          git diff --cached --quiet && echo "No baseline changes to commit" && exit 0
+          git commit -m "Update test baseline [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ This repository is an open source project and can be used independently of the [
 
 It works best overall when used together with the feddi Platform. For full documentation on running the feddi Gateway with the feddi Platform — including pre-built binaries — see [feddi.dev/get-started](https://feddi.dev/get-started).
 
+## Tests
+
+<!-- test-results-start -->
+Baseline test results are populated automatically after the next successful `main` build.
+<!-- test-results-end -->
+
 ## Requirements
 
 - Java 25 or later

--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -1,6 +1,19 @@
+plugins {
+    id 'jacoco'
+}
+
+jacoco {
+    toolVersion = '0.8.14'
+}
+
+repositories {
+    mavenCentral()
+}
+
 subprojects {
     apply plugin: 'java'
     apply plugin: 'checkstyle'
+    apply plugin: 'jacoco'
 
     java {
         toolchain {
@@ -24,12 +37,50 @@ subprojects {
         maxErrors = 0
     }
 
+    jacoco {
+        toolVersion = rootProject.jacoco.toolVersion
+    }
+
     // Exclude generated sources from checkstyle
     tasks.named('checkstyleMain') {
         source = fileTree('src/main/java')
     }
 
-    tasks.named('test') {
+    tasks.withType(Test).configureEach {
         useJUnitPlatform()
+    }
+}
+
+tasks.register('jacocoAggregateReport', JacocoReport) {
+    group = 'verification'
+    description = 'Generates an aggregate JaCoCo coverage report for gateway Java code.'
+
+    def coveredProjects = subprojects.findAll { it.plugins.hasPlugin('java') }
+    def testTasks = coveredProjects.collectMany { project ->
+        project.tasks.withType(Test).findAll { it.name in ['test', 'integrationTest'] }
+    }
+
+    mustRunAfter testTasks
+
+    executionData.from coveredProjects.collect { project ->
+        project.fileTree(project.layout.buildDirectory.dir('jacoco').get().asFile) {
+            include '*.exec'
+        }
+    }
+
+    sourceDirectories.from coveredProjects.collect { project ->
+        project.sourceSets.main.allSource.srcDirs
+    }
+
+    classDirectories.from coveredProjects.collect { project ->
+        project.fileTree(project.layout.buildDirectory.dir('classes/java/main').get().asFile) {
+            exclude 'dev/feddi/federation/engine/parser/antlr/**'
+        }
+    }
+
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = false
     }
 }

--- a/scripts/generate-readme-test-report.js
+++ b/scripts/generate-readme-test-report.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const { updateReadmeFromBaseline } = require('../.github/scripts/test-report.js');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+updateReadmeFromBaseline({
+  baselineFile: path.join(repoRoot, 'test-baseline.json'),
+  readmeFile: path.join(repoRoot, 'README.md'),
+});
+
+console.log('README.md updated from test-baseline.json');

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -57,7 +57,7 @@ echo "=============================================="
 echo "Building and testing gateway project"
 echo "=============================================="
 cd "$PROJECT_ROOT/gateway"
-./gradlew clean test integrationTest bootJar $RERUN_TASKS
+./gradlew clean test integrationTest bootJar jacocoAggregateReport $RERUN_TASKS
 
 # Count YAML-based tests (these are dynamically generated)
 COMPOSITION_SUCCESS_TESTS=$(count_yaml_tests "*/composition/success/*")

--- a/test-baseline.json
+++ b/test-baseline.json
@@ -1,0 +1,8 @@
+{
+  "tests": {},
+  "categories": {},
+  "coverage": {
+    "overall": {},
+    "classes": {}
+  }
+}


### PR DESCRIPTION
## Summary
- add test-baseline.json bootstrap and generated README test report markers
- add JaCoCo aggregate coverage and test stats/reporting helpers
- add PR coverage gate and PR test report comment workflow
- publish baseline and README updates from successful main builds using BASELINE_DEPLOY_KEY

## Validation
- node .github/scripts/test-report.test.js
- workflow YAML parse
- ./gateway/gradlew -p gateway clean test integrationTest jacocoAggregateReport --rerun-tasks
- ./scripts/run-all-tests.sh --cached
- git diff --check