### PR TITLE
Fix nested entity lookup execution contexts

### DIFF
--- a/gateway/engine/src/main/java/dev/feddi/federation/engine/executor/Executor.java
+++ b/gateway/engine/src/main/java/dev/feddi/federation/engine/executor/Executor.java
@@ -349,29 +349,13 @@ public final class Executor {
     private Mono<StepResult> executeRepeatedStep(ExecutionStep step, SubgraphClient client,
                                                  ExecutionContext ctx, Map<String, Object> queryVariables) {
         int parentStepId = step.dependsOn().get(0);
-
-        // First try nested contexts, then fall back to top-level contexts
-        List<Map<String, Object>> parentContexts = ctx.getNestedContexts(parentStepId);
-        if (parentContexts == null || parentContexts.isEmpty()) {
-            parentContexts = ctx.getDataContexts(parentStepId);
-        }
-
-        // If contexts don't match the requirements, search for matching entities in the merged data
-        // This handles cases where entities are nested deeper (e.g., { b: { a: [items] } })
-        if (parentContexts != null && !parentContexts.isEmpty() && !step.requirements().isEmpty()) {
-            Set<String> requiredFields = getRequiredTopLevelFields(step.requirements());
-            if (!contextsSatisfyRequirements(parentContexts, requiredFields)) {
-                // Search for entities that have the required fields
-                parentContexts = findMatchingEntities(ctx.getMergedData(), requiredFields);
-            }
-        }
+        List<Map<String, Object>> parentContexts = selectParentContexts(step, ctx, parentStepId);
 
         if (parentContexts == null || parentContexts.isEmpty()) {
             return Mono.just(new StepResult(step.id()));
         }
 
         final List<Map<String, Object>> contexts = parentContexts;
-        final Set<String> requiredVarNames = step.requirements().keySet();
         // Get field names that should be set to null for skipped entities
         final Set<String> nullFieldNames = getFirstLevelFieldNames(step.operation());
 
@@ -442,7 +426,7 @@ public final class Executor {
                             }
                             resultContexts.add(er.context());
 
-                            List<Map<String, Object>> nested = extractNestedEntities(data);
+                            List<Map<String, Object>> nested = extractNestedContexts(data);
                             allNestedEntities.addAll(nested);
                         }
                     } else {
@@ -911,118 +895,176 @@ public final class Executor {
     }
 
     /**
-     * Gets the top-level field names required by a step's requirements.
-     * For single-alternative requirements, returns the field name directly.
-     * For multi-alternative requirements (e.g., {@code <Book>.isbn | <Electronics>.sku}),
-     * returns field names from all alternatives. Use {@link #contextsSatisfyRequirements}
-     * which handles per-alternative checking.
+     * Selects the concrete response objects that should drive a repeated lookup.
+     *
+     * Nested contexts are preferred because they represent objects produced below
+     * the parent lookup root. If none of them carry the fields required by this
+     * lookup, fall back to the direct parent contexts. That fallback is important
+     * for multi-hop lookups where a previous lookup merged a translated key into
+     * the original entity object, including the null-key propagation path.
      */
-    private Set<String> getRequiredTopLevelFields(Map<String, SelectedValue> requirements) {
-        Set<String> fields = new HashSet<>();
-        for (SelectedValue value : requirements.values()) {
-            for (Alternative alt : value.alternatives()) {
-                if (alt instanceof Path path && !path.segments().isEmpty()) {
-                    fields.add(path.segments().get(0).fieldName());
-                }
+    private List<Map<String, Object>> selectParentContexts(ExecutionStep step, ExecutionContext ctx, int parentStepId) {
+        List<Map<String, Object>> nestedContexts =
+            filterContextsForRequirements(ctx.getNestedContexts(parentStepId), step.requirements());
+        if (!nestedContexts.isEmpty()) {
+            return nestedContexts;
+        }
+
+        List<Map<String, Object>> dataContexts =
+            filterContextsForRequirements(ctx.getDataContexts(parentStepId), step.requirements());
+        if (!dataContexts.isEmpty()) {
+            return dataContexts;
+        }
+
+        if (step.requirements().isEmpty()) {
+            return List.of();
+        }
+
+        return findMatchingContexts(ctx.getMergedData(), step.requirements());
+    }
+
+    private List<Map<String, Object>> filterContextsForRequirements(List<Map<String, Object>> contexts,
+                                                                     Map<String, SelectedValue> requirements) {
+        if (contexts == null || contexts.isEmpty()) {
+            return List.of();
+        }
+        if (requirements.isEmpty()) {
+            return contexts;
+        }
+
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (Map<String, Object> context : contexts) {
+            if (contextCanProvideRequirements(context, requirements)) {
+                result.add(context);
             }
         }
-        return fields;
+        return result;
     }
 
     /**
-     * Checks if the given contexts can satisfy the required fields.
-     * For each requirement, at least one alternative's fields must be present in the context.
-     * Returns true if at least one context satisfies all requirements.
+     * Checks whether a context has the source fields for every requirement.
+     * Null values count as present so downstream steps can still write nulls for
+     * fields that cannot be resolved after a null lookup.
      */
-    private boolean contextsSatisfyRequirements(List<Map<String, Object>> contexts, Set<String> requiredFields) {
-        if (requiredFields.isEmpty()) {
-            return true;
-        }
-        for (Map<String, Object> context : contexts) {
-            // Check if any required field is present (alternatives mean any one suffices)
-            boolean hasAny = false;
-            for (String field : requiredFields) {
-                if (context.containsKey(field)) {
-                    hasAny = true;
-                    break;
-                }
+    private boolean contextCanProvideRequirements(Map<String, Object> context,
+                                                   Map<String, SelectedValue> requirements) {
+        for (SelectedValue selectedValue : requirements.values()) {
+            if (!contextCanProvideSelectedValue(context, selectedValue)) {
+                return false;
             }
-            if (hasAny) {
+        }
+        return true;
+    }
+
+    private boolean contextCanProvideSelectedValue(Map<String, Object> context, SelectedValue selectedValue) {
+        for (Alternative alt : selectedValue.alternatives()) {
+            if (contextCanProvideAlternative(context, alt)) {
                 return true;
             }
         }
         return false;
     }
 
+    private boolean contextCanProvideAlternative(Map<String, Object> context, Alternative alt) {
+        return switch (alt) {
+            case Path path -> contextHasPathSource(context, path);
+            case ObjectSelection obj -> contextCanProvideObjectSelection(context, obj);
+            case ListSelection list -> list.pathPrefix() != null
+                && contextHasPathSource(context, list.pathPrefix());
+        };
+    }
+
+    private boolean contextCanProvideObjectSelection(Map<String, Object> context, ObjectSelection obj) {
+        if (obj.pathPrefix() != null) {
+            return contextHasPathSource(context, obj.pathPrefix());
+        }
+        for (ObjectField field : obj.fields()) {
+            if (!contextCanProvideSelectedValue(context, field.value())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean contextHasPathSource(Map<String, Object> context, Path path) {
+        if (path.hasInitialTypeCondition()) {
+            String typename = (String) context.get(IntrospectionFields.TYPENAME);
+            if (typename == null || !path.initialTypeCondition().equals(typename)) {
+                return false;
+            }
+        }
+        if (path.segments().isEmpty()) {
+            return true;
+        }
+        return context.containsKey(path.segments().get(0).fieldName());
+    }
+
     /**
-     * Finds entities in the data structure that have all the required fields.
-     * Searches recursively through nested maps and lists.
+     * Finds matching contexts in merged data when the direct parent context is a
+     * wrapper object around the actual entity, such as { container: { book } }.
      */
-    private List<Map<String, Object>> findMatchingEntities(Map<String, Object> data, Set<String> requiredFields) {
+    private List<Map<String, Object>> findMatchingContexts(Map<String, Object> data,
+                                                            Map<String, SelectedValue> requirements) {
         List<Map<String, Object>> result = new ArrayList<>();
-        findMatchingEntitiesRecursive(data, requiredFields, result);
+        findMatchingContextsRecursive(data, requirements, result);
         return result;
     }
 
-    private void findMatchingEntitiesRecursive(Object data, Set<String> requiredFields, List<Map<String, Object>> result) {
+    private void findMatchingContextsRecursive(Object data, Map<String, SelectedValue> requirements,
+                                               List<Map<String, Object>> result) {
         if (data instanceof Map) {
             @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) data;
 
-            // Check if this map has all required fields
-            if (map.keySet().containsAll(requiredFields)) {
+            if (contextCanProvideRequirements(map, requirements)) {
                 result.add(map);
-                // Don't recurse into this map's children - we found a match
                 return;
             }
 
-            // Recurse into values
             for (Object value : map.values()) {
-                findMatchingEntitiesRecursive(value, requiredFields, result);
+                findMatchingContextsRecursive(value, requirements, result);
             }
         } else if (data instanceof List) {
             @SuppressWarnings("unchecked")
             List<Object> list = (List<Object>) data;
             for (Object item : list) {
-                findMatchingEntitiesRecursive(item, requiredFields, result);
+                findMatchingContextsRecursive(item, requirements, result);
             }
         }
     }
 
     /**
-     * Extracts nested entities (objects with 'id' fields) from response data.
+     * Extracts context candidates below a lookup root. The lookup root object is
+     * not itself added because repeated lookup results are merged into the
+     * original parent context; only objects nested beneath that result can be
+     * independent contexts for later lookups.
      */
-    private List<Map<String, Object>> extractNestedEntities(Map<String, Object> data) {
+    private List<Map<String, Object>> extractNestedContexts(Map<String, Object> data) {
         List<Map<String, Object>> nested = new ArrayList<>();
-        extractNestedEntitiesRecursive(data, nested);
+        for (Object value : data.values()) {
+            extractNestedContextsRecursive(value, nested, false);
+        }
         return nested;
     }
 
-    /**
-     * Recursively extracts entities with 'id' fields from nested data structures.
-     */
-    private void extractNestedEntitiesRecursive(Object data, List<Map<String, Object>> result) {
+    private void extractNestedContextsRecursive(Object data, List<Map<String, Object>> result,
+                                                boolean includeCurrent) {
         if (data instanceof Map) {
             @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) data;
 
+            if (includeCurrent) {
+                result.add(map);
+            }
+
             for (Object value : map.values()) {
-                if (value instanceof List) {
-                    @SuppressWarnings("unchecked")
-                    List<Object> list = (List<Object>) value;
-                    for (Object item : list) {
-                        if (item instanceof Map) {
-                            @SuppressWarnings("unchecked")
-                            Map<String, Object> itemMap = (Map<String, Object>) item;
-                            if (itemMap.containsKey("id")) {
-                                result.add(itemMap);
-                            }
-                            extractNestedEntitiesRecursive(itemMap, result);
-                        }
-                    }
-                } else if (value instanceof Map) {
-                    extractNestedEntitiesRecursive(value, result);
-                }
+                extractNestedContextsRecursive(value, result, true);
+            }
+        } else if (data instanceof List) {
+            @SuppressWarnings("unchecked")
+            List<Object> list = (List<Object>) data;
+            for (Object item : list) {
+                extractNestedContextsRecursive(item, result, true);
             }
         }
     }

--- a/gateway/engine/src/test/resources/schemas/benchmark_heavy_query/executions/01_nested_product_entity_fields.yaml
+++ b/gateway/engine/src/test/resources/schemas/benchmark_heavy_query/executions/01_nested_product_entity_fields.yaml
@@ -1,0 +1,78 @@
+name: "Nested product entity fields are merged"
+description: |
+  A Product entity returned under a Review is keyed by upc rather than id. The
+  executor must use that nested Product object as the context for downstream
+  product and inventory lookups, then merge the fetched fields back into the
+  same nested response object.
+
+query: |
+  fragment ProductFields on Product {
+    inStock
+    name
+    price
+    shippingEstimate
+    upc
+    weight
+  }
+
+  {
+    users {
+      id
+      reviews {
+        id
+        product {
+          ...ProductFields
+          reviews {
+            id
+          }
+        }
+      }
+    }
+  }
+
+variables: {}
+
+subgraphCalls:
+  - subgraph: accounts
+    operation: '{users{id}}'
+    variables: {}
+    response: { data: { users: [{ id: "u1" }] } }
+
+  - subgraph: reviews
+    operation: 'query ($id:ID!){user(id:$id){reviews{id product{upc reviews{id}}}}}'
+    variables: { id: "u1" }
+    response: { data: { user: { reviews: [{ id: "r1", product: { upc: "p1", reviews: [{ id: "r1" }] } }] } } }
+
+  - subgraph: products
+    operation: 'query ($upc:ID!){product(upc:$upc){name price weight}}'
+    variables: { upc: "p1" }
+    response: { data: { product: { name: "Table", price: 899, weight: 100 } } }
+
+  - subgraph: inventory
+    operation: 'query ($upc:ID!,$weight:Long!,$price:Long!){productByUpc(upc:$upc){inStock shippingEstimate(weight:$weight,price:$price)}}'
+    variables: { upc: "p1", price: 899, weight: 100 }
+    response: { data: { productByUpc: { inStock: true, shippingEstimate: 999 } } }
+
+expectedResponse: {
+  data: {
+    users: [
+      {
+        id: "u1",
+        reviews: [
+          {
+            id: "r1",
+            product: {
+              inStock: true,
+              name: "Table",
+              price: 899,
+              shippingEstimate: 999,
+              upc: "p1",
+              weight: 100,
+              reviews: [{ id: "r1" }]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/gateway/engine/src/test/resources/schemas/benchmark_heavy_query/executions/02_multiple_nested_product_entities.yaml
+++ b/gateway/engine/src/test/resources/schemas/benchmark_heavy_query/executions/02_multiple_nested_product_entities.yaml
@@ -1,0 +1,102 @@
+name: "Multiple nested product entities are merged independently"
+description: |
+  Multiple Product entities returned under Review objects must each drive their
+  own downstream lookups. Fields fetched for one Product must not be merged into
+  another Product at a different list position.
+
+query: |
+  fragment ProductFields on Product {
+    inStock
+    name
+    price
+    shippingEstimate
+    upc
+    weight
+  }
+
+  {
+    users {
+      id
+      reviews {
+        id
+        product {
+          ...ProductFields
+          reviews {
+            id
+          }
+        }
+      }
+    }
+  }
+
+variables: {}
+
+subgraphCalls:
+  - subgraph: accounts
+    operation: '{users{id}}'
+    variables: {}
+    response: { data: { users: [{ id: "u1" }] } }
+
+  - subgraph: reviews
+    operation: 'query ($id:ID!){user(id:$id){reviews{id product{upc reviews{id}}}}}'
+    variables: { id: "u1" }
+    response: { data: { user: { reviews: [
+      { id: "r1", product: { upc: "p1", reviews: [{ id: "r1" }] } },
+      { id: "r2", product: { upc: "p2", reviews: [{ id: "r2" }] } }
+    ] } } }
+
+  - subgraph: products
+    operation: 'query ($upc:ID!){product(upc:$upc){name price weight}}'
+    variables: { upc: "p1" }
+    response: { data: { product: { name: "Table", price: 899, weight: 100 } } }
+
+  - subgraph: products
+    operation: 'query ($upc:ID!){product(upc:$upc){name price weight}}'
+    variables: { upc: "p2" }
+    response: { data: { product: { name: "Chair", price: 54, weight: 8 } } }
+
+  - subgraph: inventory
+    operation: 'query ($upc:ID!,$weight:Long!,$price:Long!){productByUpc(upc:$upc){inStock shippingEstimate(weight:$weight,price:$price)}}'
+    variables: { upc: "p1", price: 899, weight: 100 }
+    response: { data: { productByUpc: { inStock: true, shippingEstimate: 999 } } }
+
+  - subgraph: inventory
+    operation: 'query ($upc:ID!,$weight:Long!,$price:Long!){productByUpc(upc:$upc){inStock shippingEstimate(weight:$weight,price:$price)}}'
+    variables: { upc: "p2", price: 54, weight: 8 }
+    response: { data: { productByUpc: { inStock: false, shippingEstimate: 62 } } }
+
+expectedResponse: {
+  data: {
+    users: [
+      {
+        id: "u1",
+        reviews: [
+          {
+            id: "r1",
+            product: {
+              inStock: true,
+              name: "Table",
+              price: 899,
+              shippingEstimate: 999,
+              upc: "p1",
+              weight: 100,
+              reviews: [{ id: "r1" }]
+            }
+          },
+          {
+            id: "r2",
+            product: {
+              inStock: false,
+              name: "Chair",
+              price: 54,
+              shippingEstimate: 62,
+              upc: "p2",
+              weight: 8,
+              reviews: [{ id: "r2" }]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/gateway/engine/src/test/resources/schemas/benchmark_heavy_query/executions/03_nested_product_lookup_null.yaml
+++ b/gateway/engine/src/test/resources/schemas/benchmark_heavy_query/executions/03_nested_product_lookup_null.yaml
@@ -1,0 +1,97 @@
+name: "Null nested product lookup is scoped to that product"
+description: |
+  If one nested Product entity lookup returns null, only that Product object
+  should receive nulls for fields from downstream subgraphs. Other nested
+  Product entities in the same response should still be completed normally.
+
+query: |
+  fragment ProductFields on Product {
+    inStock
+    name
+    price
+    shippingEstimate
+    upc
+    weight
+  }
+
+  {
+    users {
+      id
+      reviews {
+        id
+        product {
+          ...ProductFields
+          reviews {
+            id
+          }
+        }
+      }
+    }
+  }
+
+variables: {}
+
+subgraphCalls:
+  - subgraph: accounts
+    operation: '{users{id}}'
+    variables: {}
+    response: { data: { users: [{ id: "u1" }] } }
+
+  - subgraph: reviews
+    operation: 'query ($id:ID!){user(id:$id){reviews{id product{upc reviews{id}}}}}'
+    variables: { id: "u1" }
+    response: { data: { user: { reviews: [
+      { id: "r1", product: { upc: "p1", reviews: [{ id: "r1" }] } },
+      { id: "r2", product: { upc: "missing", reviews: [{ id: "r2" }] } }
+    ] } } }
+
+  - subgraph: products
+    operation: 'query ($upc:ID!){product(upc:$upc){name price weight}}'
+    variables: { upc: "p1" }
+    response: { data: { product: { name: "Table", price: 899, weight: 100 } } }
+
+  - subgraph: products
+    operation: 'query ($upc:ID!){product(upc:$upc){name price weight}}'
+    variables: { upc: "missing" }
+    response: { data: { product: null } }
+
+  - subgraph: inventory
+    operation: 'query ($upc:ID!,$weight:Long!,$price:Long!){productByUpc(upc:$upc){inStock shippingEstimate(weight:$weight,price:$price)}}'
+    variables: { upc: "p1", price: 899, weight: 100 }
+    response: { data: { productByUpc: { inStock: true, shippingEstimate: 999 } } }
+
+expectedResponse: {
+  data: {
+    users: [
+      {
+        id: "u1",
+        reviews: [
+          {
+            id: "r1",
+            product: {
+              inStock: true,
+              name: "Table",
+              price: 899,
+              shippingEstimate: 999,
+              upc: "p1",
+              weight: 100,
+              reviews: [{ id: "r1" }]
+            }
+          },
+          {
+            id: "r2",
+            product: {
+              inStock: null,
+              name: null,
+              price: null,
+              shippingEstimate: null,
+              upc: "missing",
+              weight: null,
+              reviews: [{ id: "r2" }]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/gateway/engine/src/test/resources/schemas/benchmark_heavy_query/executions/04_nested_products_across_response_paths.yaml
+++ b/gateway/engine/src/test/resources/schemas/benchmark_heavy_query/executions/04_nested_products_across_response_paths.yaml
@@ -1,0 +1,119 @@
+name: "Nested product entities are merged across response paths"
+description: |
+  The same Product lookup shape can appear below different top-level response
+  paths. Nested Product objects under each path must be completed independently.
+
+query: |
+  fragment ProductFields on Product {
+    inStock
+    name
+    price
+    shippingEstimate
+    upc
+    weight
+  }
+
+  {
+    users {
+      id
+      reviews {
+        id
+        product {
+          ...ProductFields
+        }
+      }
+    }
+    topProducts(first: 1) {
+      upc
+      reviews {
+        id
+        product {
+          ...ProductFields
+        }
+      }
+    }
+  }
+
+variables: {}
+
+subgraphCalls:
+  - subgraph: accounts
+    operation: '{users{id}}'
+    variables: {}
+    response: { data: { users: [{ id: "u1" }] } }
+
+  - subgraph: products
+    operation: '{topProducts(first:1){upc}}'
+    variables: {}
+    response: { data: { topProducts: [{ upc: "root" }] } }
+
+  - subgraph: reviews
+    operation: 'query ($id:ID!){user(id:$id){reviews{id product{upc}}}}'
+    variables: { id: "u1" }
+    response: { data: { user: { reviews: [{ id: "user-review", product: { upc: "p1" } }] } } }
+
+  - subgraph: reviews
+    operation: 'query ($upc:ID!){product(upc:$upc){reviews{id product{upc}}}}'
+    variables: { upc: "root" }
+    response: { data: { product: { reviews: [{ id: "root-review", product: { upc: "p2" } }] } } }
+
+  - subgraph: products
+    operation: 'query ($upc:ID!){product(upc:$upc){name price weight}}'
+    variables: { upc: "p1" }
+    response: { data: { product: { name: "Table", price: 899, weight: 100 } } }
+
+  - subgraph: products
+    operation: 'query ($upc:ID!){product(upc:$upc){name price weight}}'
+    variables: { upc: "p2" }
+    response: { data: { product: { name: "Chair", price: 54, weight: 8 } } }
+
+  - subgraph: inventory
+    operation: 'query ($upc:ID!,$weight:Long!,$price:Long!){productByUpc(upc:$upc){inStock shippingEstimate(weight:$weight,price:$price)}}'
+    variables: { upc: "p1", price: 899, weight: 100 }
+    response: { data: { productByUpc: { inStock: true, shippingEstimate: 999 } } }
+
+  - subgraph: inventory
+    operation: 'query ($upc:ID!,$weight:Long!,$price:Long!){productByUpc(upc:$upc){inStock shippingEstimate(weight:$weight,price:$price)}}'
+    variables: { upc: "p2", price: 54, weight: 8 }
+    response: { data: { productByUpc: { inStock: false, shippingEstimate: 62 } } }
+
+expectedResponse: {
+  data: {
+    users: [
+      {
+        id: "u1",
+        reviews: [
+          {
+            id: "user-review",
+            product: {
+              inStock: true,
+              name: "Table",
+              price: 899,
+              shippingEstimate: 999,
+              upc: "p1",
+              weight: 100
+            }
+          }
+        ]
+      }
+    ],
+    topProducts: [
+      {
+        upc: "root",
+        reviews: [
+          {
+            id: "root-review",
+            product: {
+              inStock: false,
+              name: "Chair",
+              price: 54,
+              shippingEstimate: 62,
+              upc: "p2",
+              weight: 8
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/gateway/engine/src/test/resources/schemas/nested_entity_context_selection/executions/01_type_qualified_nested_context.yaml
+++ b/gateway/engine/src/test/resources/schemas/nested_entity_context_selection/executions/01_type_qualified_nested_context.yaml
@@ -1,0 +1,57 @@
+name: "Type-qualified nested context ignores unrelated objects"
+description: |
+  A lookup requirement with an initial type condition should use only nested
+  objects of that type. An unrelated nested object with the same field name must
+  not drive the entity lookup.
+
+query: |
+  {
+    reviews {
+      id
+      product {
+        upc
+        name
+      }
+      metadata {
+        upc
+        source
+      }
+    }
+  }
+
+variables: {}
+
+subgraphCalls:
+  - subgraph: catalog
+    operation: '{reviews{id product{upc __typename} metadata{upc source}}}'
+    variables: {}
+    response: { data: { reviews: [
+      {
+        id: "r1",
+        product: { upc: "p1", __typename: "Product" },
+        metadata: { upc: "metadata-only", source: "catalog" }
+      }
+    ] } }
+
+  - subgraph: products
+    operation: 'query ($upc:ID!){product(upc:$upc){name}}'
+    variables: { upc: "p1" }
+    response: { data: { product: { name: "Table" } } }
+
+expectedResponse: {
+  data: {
+    reviews: [
+      {
+        id: "r1",
+        product: {
+          upc: "p1",
+          name: "Table"
+        },
+        metadata: {
+          upc: "metadata-only",
+          source: "catalog"
+        }
+      }
+    ]
+  }
+}

--- a/gateway/engine/src/test/resources/schemas/nested_entity_context_selection/schema.yaml
+++ b/gateway/engine/src/test/resources/schemas/nested_entity_context_selection/schema.yaml
@@ -1,0 +1,56 @@
+name: "Nested Entity Context Selection"
+description: |
+  Tests requirement-based context selection for nested entity lookups.
+
+subgraphs:
+  catalog: |
+    type Query {
+      reviews: [Review!]!
+    }
+
+    type Review {
+      id: ID!
+      product: Product!
+      metadata: ProductMetadata!
+    }
+
+    type Product @key(fields: "upc") {
+      upc: ID!
+    }
+
+    type ProductMetadata {
+      upc: ID!
+      source: String
+    }
+
+  products: |
+    type Query {
+      product(upc: ID! @is(field: "<Product>.upc")): Product @lookup
+    }
+
+    type Product @key(fields: "upc") {
+      upc: ID!
+      name: String!
+    }
+
+supergraph: |
+  type Query {
+    reviews: [Review!]!
+    product(upc: ID!): Product
+  }
+
+  type Review {
+    id: ID!
+    product: Product!
+    metadata: ProductMetadata!
+  }
+
+  type Product {
+    upc: ID!
+    name: String!
+  }
+
+  type ProductMetadata {
+    upc: ID!
+    source: String
+  }


### PR DESCRIPTION
## Summary

Fix repeated entity lookup execution when a later lookup must start from an entity object nested inside a previous lookup result.

In GraphQL federation terms, a subgraph can return a partial entity object as part of another entity's selection set. If that nested entity is keyed by a field other than `id`, later lookups still need to use that exact nested object as their source context and merge fetched fields back into it.

## Problem

The executor collected nested lookup contexts using a hard-coded `id`-field heuristic. That missed valid entity objects keyed by other fields, such as `Product.upc`, when they appeared below another lookup result:

```graphql
users {
  reviews {
    product {
      upc
      name
      inStock
      shippingEstimate
      reviews { id }
    }
  }
}
```

The `reviews` subgraph could return the nested `product { upc reviews { id } }`, but later `products` and `inventory` lookups were not reliably driven from that nested `Product` object. The final response could therefore keep only the fields returned by the first subgraph and omit fields fetched from other subgraphs for the same entity position.

## Fix

- Select repeated lookup parent contexts by checking each candidate object against the lookup step's actual requirement map.
- Collect nested context candidates below lookup roots without assuming a specific key field name.
- Preserve direct-context fallback for multi-hop key translation and null-key propagation.
- Add an execution fixture that verifies a nested `Product` keyed by `upc` is completed across `reviews`, `products`, and `inventory` lookups.

## Verification

- `./scripts/run-all-tests.sh -c`
- `./scripts/hooks/pre-commit`
- `./scripts/run-all-tests.sh`
