### PR TITLE
Add --enable-native-access=ALL-UNNAMED to suppress Netty JVM warning

### DIFF
--- a/gateway/dist/bin/feddi-gateway
+++ b/gateway/dist/bin/feddi-gateway
@@ -103,7 +103,8 @@ DEFAULT_JVM_OPTS="\
  -XX:+AlwaysPreTouch \
  -XX:+ExitOnOutOfMemoryError \
  -XX:+HeapDumpOnOutOfMemoryError \
- -XX:-OmitStackTraceInFastThrow"
+ -XX:-OmitStackTraceInFastThrow \
+ --enable-native-access=ALL-UNNAMED"
 
 # --------------------------------------------------------------------------
 # Launch the feddi Gateway

--- a/gateway/dist/bin/feddi-gateway.bat
+++ b/gateway/dist/bin/feddi-gateway.bat
@@ -84,7 +84,7 @@ if not exist "%APP_HOME%\app.jar" (
 @rem --------------------------------------------------------------------------
 @rem Default JVM options
 @rem --------------------------------------------------------------------------
-set DEFAULT_JVM_OPTS=-XX:+UseZGC -Xms256m -Xmx1g -XX:SoftMaxHeapSize=768m -XX:+UseStringDeduplication -XX:+AlwaysPreTouch -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow
+set DEFAULT_JVM_OPTS=-XX:+UseZGC -Xms256m -Xmx1g -XX:SoftMaxHeapSize=768m -XX:+UseStringDeduplication -XX:+AlwaysPreTouch -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow --enable-native-access=ALL-UNNAMED
 
 @rem --------------------------------------------------------------------------
 @rem Launch the feddi Gateway


### PR DESCRIPTION
## Summary
Adds `--enable-native-access=ALL-UNNAMED` to the default JVM options in both the Unix and Windows launcher scripts.

Netty calls `System::loadLibrary` from an unnamed module to load its native libraries. Java 25 flags this as a restricted method and warns that it will be blocked in a future release. This flag is the official opt-in for unnamed-module native access and suppresses the warning. Netty's JARs are not named modules, so `ALL-UNNAMED` is the only available target.

## Test plan
- [ ] Gateway starts without the `WARNING: A restricted method in java.lang.System has been called` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)