### PR TITLE
Implement @require argument nullability handling

### DIFF
--- a/gateway/engine/src/main/java/dev/feddi/federation/engine/executor/Executor.java
+++ b/gateway/engine/src/main/java/dev/feddi/federation/engine/executor/Executor.java
@@ -3,6 +3,7 @@ package dev.feddi.federation.engine.executor;
 import dev.feddi.federation.engine.IntrospectionFields;
 import dev.feddi.federation.engine.planner.ExecutionPlan;
 import dev.feddi.federation.engine.planner.ExecutionStep;
+import dev.feddi.federation.engine.planner.RequireArgumentSkipInfo;
 import dev.feddi.federation.engine.parser.FieldSelectionMap.Alternative;
 import dev.feddi.federation.engine.parser.FieldSelectionMap.ListSelection;
 import dev.feddi.federation.engine.parser.FieldSelectionMap.ObjectField;
@@ -176,16 +177,22 @@ public final class Executor {
             return executeIntrospectionStep(step, Map.of());
         }
 
+        // Resolve the subgraph client lazily inside repeated/single execution so that
+        // steps which skip every entity (e.g. non-null @require resolved to null) do
+        // not fail just because no client was registered for an unused subgraph.
+        if (step.repeatedExecution()) {
+            return executeRepeatedStep(step, ctx, queryVariables);
+        } else {
+            return executeSingleDependentStep(step, ctx, queryVariables);
+        }
+    }
+
+    private SubgraphClient requireClient(ExecutionStep step) {
         SubgraphClient client = subgraphClients.get(step.subgraph());
         if (client == null) {
-            return Mono.error(new ExecutionException("No client for subgraph: " + step.subgraph()));
+            throw new ExecutionException("No client for subgraph: " + step.subgraph());
         }
-
-        if (step.repeatedExecution()) {
-            return executeRepeatedStep(step, client, ctx, queryVariables);
-        } else {
-            return executeSingleDependentStep(step, client, ctx, queryVariables);
-        }
+        return client;
     }
 
     /**
@@ -346,7 +353,7 @@ public final class Executor {
     /**
      * Executes a repeated step for each parent entity in parallel.
      */
-    private Mono<StepResult> executeRepeatedStep(ExecutionStep step, SubgraphClient client,
+    private Mono<StepResult> executeRepeatedStep(ExecutionStep step,
                                                  ExecutionContext ctx, Map<String, Object> queryVariables) {
         int parentStepId = step.dependsOn().get(0);
         List<Map<String, Object>> parentContexts = selectParentContexts(step, ctx, parentStepId);
@@ -369,11 +376,23 @@ public final class Executor {
                 Map<String, Object> extractedVars = extractVariables(step.requirements(), context);
                 stepVariables.putAll(extractedVars);
 
-                // Skip entities that don't have essential key fields (null key handling)
-                // This happens when an intermediate lookup returned null.
-                // We check if key fields EXIST in context (not if they're null).
-                if (!hasEssentialKeyFields(step.requirements(), context)) {
+                // Skip entities that don't have essential @is key fields (null key handling).
+                if (!hasEssentialKeyFields(step.keyRequirements(), context)) {
                     return Mono.just(new EntityResult(context, null));
+                }
+
+                // Skip when a non-null @require argument resolved to null (Cases 2/3).
+                // Nullable @require args (Case 1) are intentionally allowed through with null.
+                List<GraphQLError> requireNullErrors = collectRequiredArgumentNullErrors(step, extractedVars);
+                if (requireNullErrors != null) {
+                    return Mono.just(new EntityResult(context, null, null, requireNullErrors));
+                }
+
+                SubgraphClient client;
+                try {
+                    client = requireClient(step);
+                } catch (ExecutionException e) {
+                    return Mono.error(e);
                 }
 
                 long entityStart = System.nanoTime();
@@ -441,6 +460,13 @@ public final class Executor {
                         // Still add to resultContexts so downstream steps can set their fields to null
                         resultContexts.add(er.context());
 
+                        // Case 3: non-null @require + non-null field return → REQUIRED_ARGUMENT_NULL
+                        if (er.skipErrors() != null) {
+                            for (GraphQLError error : er.skipErrors()) {
+                                stepResult.addError(error);
+                            }
+                        }
+
                         // If there was an error (e.g., timeout), record it
                         if (er.error() != null) {
                             if (er.error() instanceof SubgraphTimeoutException ste) {
@@ -464,7 +490,7 @@ public final class Executor {
     /**
      * Executes a single dependent step (non-repeated).
      */
-    private Mono<StepResult> executeSingleDependentStep(ExecutionStep step, SubgraphClient client,
+    private Mono<StepResult> executeSingleDependentStep(ExecutionStep step,
                                                         ExecutionContext ctx, Map<String, Object> queryVariables) {
         int parentStepId = step.dependsOn().get(0);
         Map<String, Object> parentData = ctx.getStepData(parentStepId);
@@ -478,6 +504,8 @@ public final class Executor {
         Map<String, Object> stepVariables = new LinkedHashMap<>(
             filterVariablesForOperation(step.operation(), queryVariables));
         stepVariables.putAll(extractVariables(step.requirements(), parentData));
+
+        SubgraphClient client = requireClient(step);
 
         long depStart = System.nanoTime();
         return client.execute(step.operation(), stepVariables)
@@ -632,7 +660,36 @@ public final class Executor {
     }
 
     /**
-     * Checks if essential key fields are present and non-null in the context.
+     * If any non-null {@code @require} argument extracted to null, returns an (possibly empty)
+     * list of Case 3 errors and signals that the subgraph call should be skipped.
+     * Returns {@code null} when the call should proceed.
+     */
+    private List<GraphQLError> collectRequiredArgumentNullErrors(ExecutionStep step,
+                                                                  Map<String, Object> extractedVars) {
+        if (step.nonNullRequireArguments().isEmpty()) {
+            return null;
+        }
+
+        boolean shouldSkip = false;
+        List<GraphQLError> errors = new ArrayList<>();
+        for (var entry : step.nonNullRequireArguments().entrySet()) {
+            if (extractedVars.get(entry.getKey()) != null) {
+                continue;
+            }
+            shouldSkip = true;
+            RequireArgumentSkipInfo info = entry.getValue();
+            if (info.fieldReturnNonNull()) {
+                errors.add(new RequiredArgumentNullError(info.fieldName(), entry.getKey()));
+            }
+        }
+        return shouldSkip ? errors : null;
+    }
+
+    /**
+     * Checks if essential {@code @is} key fields are present and non-null in the context.
+     *
+     * Only lookup-key requirements should be passed here — {@code @require} arguments are
+     * excluded so a null nullable required value still triggers a subgraph call.
      *
      * For single-segment paths (like "id"), the field must exist AND be non-null.
      * This handles the case where a lookup returned null and the executor added
@@ -1166,10 +1223,16 @@ public final class Executor {
      * @param context the entity context that was used for this execution
      * @param result the execution result, or null if skipped/failed
      * @param error optional error if the execution failed (e.g., timeout)
+     * @param skipErrors optional GraphQL errors produced when skipping due to null @require values
      */
-    private record EntityResult(Map<String, Object> context, ExecutionResult result, Throwable error) {
+    private record EntityResult(Map<String, Object> context, ExecutionResult result, Throwable error,
+                                List<GraphQLError> skipErrors) {
         EntityResult(Map<String, Object> context, ExecutionResult result) {
-            this(context, result, null);
+            this(context, result, null, null);
+        }
+
+        EntityResult(Map<String, Object> context, ExecutionResult result, Throwable error) {
+            this(context, result, error, null);
         }
     }
 

--- a/gateway/engine/src/main/java/dev/feddi/federation/engine/executor/RequiredArgumentNullError.java
+++ b/gateway/engine/src/main/java/dev/feddi/federation/engine/executor/RequiredArgumentNullError.java
@@ -1,0 +1,50 @@
+package dev.feddi.federation.engine.executor;
+
+import graphql.ErrorClassification;
+import graphql.GraphQLError;
+import graphql.language.SourceLocation;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * GraphQL error when a non-null {@code @require} argument resolves to null
+ * for a field whose return type is also non-null.
+ */
+public record RequiredArgumentNullError(String fieldName, String argumentName) implements GraphQLError {
+
+    private static final String ERROR_CODE = "REQUIRED_ARGUMENT_NULL";
+
+    public RequiredArgumentNullError {
+        if (fieldName == null || fieldName.isBlank()) {
+            throw new IllegalArgumentException("fieldName cannot be null or blank");
+        }
+        if (argumentName == null || argumentName.isBlank()) {
+            throw new IllegalArgumentException("argumentName cannot be null or blank");
+        }
+    }
+
+    @Override
+    public String getMessage() {
+        return "Cannot resolve field '" + fieldName + "': required argument '"
+            + argumentName + "' resolved to null";
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return null;
+    }
+
+    @Override
+    public ErrorClassification getErrorType() {
+        return ErrorClassification.errorClassification(ERROR_CODE);
+    }
+
+    @Override
+    public Map<String, Object> getExtensions() {
+        return Map.of(
+            "code", ERROR_CODE,
+            "argumentName", argumentName
+        );
+    }
+}

--- a/gateway/engine/src/main/java/dev/feddi/federation/engine/graph/GraphBuilder.java
+++ b/gateway/engine/src/main/java/dev/feddi/federation/engine/graph/GraphBuilder.java
@@ -466,8 +466,9 @@ public final class GraphBuilder {
                     try {
                         SelectedValue selection = FieldSelectionMapParser.parseFieldSelectionMap(fieldSelectionMap);
                         Type<?> argType = convertToLanguageType(arg.getType());
+                        boolean fieldReturnNonNull = GraphQLTypeUtil.isNonNull(field.getType());
                         // Include the field name so the planner knows which field this requirement belongs to
-                        requirements.add(Requirement.of(arg.getName(), selection, argType, fieldName));
+                        requirements.add(Requirement.of(arg.getName(), selection, argType, fieldName, fieldReturnNonNull));
                     } catch (InvalidSyntaxException e) {
                         throw new IllegalArgumentException(
                             "Invalid @require field selection on argument '" + arg.getName() +

--- a/gateway/engine/src/main/java/dev/feddi/federation/engine/graph/Requirement.java
+++ b/gateway/engine/src/main/java/dev/feddi/federation/engine/graph/Requirement.java
@@ -15,8 +15,15 @@ import java.util.List;
  * @param selection the parsed FieldSelectionMap value specifying required fields
  * @param argumentType the GraphQL AST type of the argument (may be null if not available)
  * @param fieldName the name of the field that has this @require argument (may be null)
+ * @param fieldReturnNonNull true when the owning field's return type is non-null
  */
-public record Requirement(String argumentName, SelectedValue selection, Type<?> argumentType, String fieldName) {
+public record Requirement(
+    String argumentName,
+    SelectedValue selection,
+    Type<?> argumentType,
+    String fieldName,
+    boolean fieldReturnNonNull
+) {
 
     public Requirement {
         if (argumentName == null || argumentName.isBlank()) {
@@ -32,30 +39,38 @@ public record Requirement(String argumentName, SelectedValue selection, Type<?> 
      * Creates a Requirement from an argument name and parsed selection (without type).
      */
     public static Requirement of(String argumentName, SelectedValue selection) {
-        return new Requirement(argumentName, selection, null, null);
+        return new Requirement(argumentName, selection, null, null, false);
     }
 
     /**
      * Creates a Requirement from an argument name, parsed selection, and type.
      */
     public static Requirement of(String argumentName, SelectedValue selection, Type<?> argumentType) {
-        return new Requirement(argumentName, selection, argumentType, null);
+        return new Requirement(argumentName, selection, argumentType, null, false);
     }
 
     /**
-     * Creates a Requirement with all fields including the source field name.
+     * Creates a Requirement with field name and return nullability.
+     */
+    public static Requirement of(String argumentName, SelectedValue selection, Type<?> argumentType,
+                                 String fieldName, boolean fieldReturnNonNull) {
+        return new Requirement(argumentName, selection, argumentType, fieldName, fieldReturnNonNull);
+    }
+
+    /**
+     * Creates a Requirement with field name (return type treated as nullable).
      */
     public static Requirement of(String argumentName, SelectedValue selection, Type<?> argumentType, String fieldName) {
-        return new Requirement(argumentName, selection, argumentType, fieldName);
+        return new Requirement(argumentName, selection, argumentType, fieldName, false);
     }
-    
+
     public List<Path> extractPaths() {
         return selection.extractPaths();
     }
 
     @Override
     public String toString() {
-        return String.format("@require(field: \"%s\") on argument '%s'", 
+        return String.format("@require(field: \"%s\") on argument '%s'",
             FieldSelectionMapPrinter.print(selection), argumentName);
     }
 }

--- a/gateway/engine/src/main/java/dev/feddi/federation/engine/planner/ExecutionStep.java
+++ b/gateway/engine/src/main/java/dev/feddi/federation/engine/planner/ExecutionStep.java
@@ -10,6 +10,7 @@ import graphql.language.Selection;
 import graphql.language.SelectionSet;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -28,6 +29,11 @@ import java.util.stream.Collectors;
  * @param repeatedExecution true if this step may need to be executed multiple times (once per entity from parent step)
  * @param artificialFieldPaths dot-notation paths of fields added for internal purposes (not requested by client)
  * @param requestedFieldPaths dot-notation paths of fields explicitly requested by the client
+ * @param keyRequirementNames requirement argument names that come from {@code @is} lookup keys.
+ *        Null/missing keys skip the subgraph call.
+ * @param nonNullRequireArguments non-null {@code @require} arguments keyed by argument name, with
+ *        owning field metadata. Null resolved values skip the subgraph call (Cases 2/3); Case 3
+ *        also emits {@code REQUIRED_ARGUMENT_NULL} when the field return type is non-null.
  */
 public record ExecutionStep(
     int id,
@@ -38,7 +44,9 @@ public record ExecutionStep(
     Map<String, SelectedValue> requirements,
     boolean repeatedExecution,
     Set<String> artificialFieldPaths,
-    Set<String> requestedFieldPaths
+    Set<String> requestedFieldPaths,
+    Set<String> keyRequirementNames,
+    Map<String, RequireArgumentSkipInfo> nonNullRequireArguments
 ) {
 
     public ExecutionStep {
@@ -56,17 +64,25 @@ public record ExecutionStep(
         requirements = requirements == null ? Map.of() : Map.copyOf(requirements);
         artificialFieldPaths = artificialFieldPaths == null ? Set.of() : Set.copyOf(artificialFieldPaths);
         requestedFieldPaths = requestedFieldPaths == null ? Set.of() : Set.copyOf(requestedFieldPaths);
+        keyRequirementNames = keyRequirementNames == null
+            ? Set.copyOf(requirements.keySet())
+            : Set.copyOf(keyRequirementNames);
+        nonNullRequireArguments = nonNullRequireArguments == null
+            ? Map.of()
+            : Map.copyOf(nonNullRequireArguments);
     }
 
     /**
      * Creates a root step with no dependencies.
      */
     public static ExecutionStep root(int id, String subgraph, OperationDefinition operation) {
-        return new ExecutionStep(id, subgraph, operation, List.of(), List.of(), Map.of(), false, Set.of(), Set.of());
+        return new ExecutionStep(id, subgraph, operation, List.of(), List.of(), Map.of(), false,
+            Set.of(), Set.of(), Set.of(), Map.of());
     }
 
     /**
      * Creates a dependent step.
+     * All requirements are treated as key requirements (legacy default).
      */
     public static ExecutionStep dependent(
         int id,
@@ -76,11 +92,14 @@ public record ExecutionStep(
         Map<String, SelectedValue> requirements,
         boolean repeatedExecution
     ) {
-        return new ExecutionStep(id, subgraph, operation, dependsOn, List.of(), requirements, repeatedExecution, Set.of(), Set.of());
+        Set<String> keyNames = requirements == null ? Set.of() : Set.copyOf(requirements.keySet());
+        return new ExecutionStep(id, subgraph, operation, dependsOn, List.of(), requirements,
+            repeatedExecution, Set.of(), Set.of(), keyNames, Map.of());
     }
 
     /**
      * Creates a dependent step with parallel execution information.
+     * All requirements are treated as key requirements (legacy default).
      */
     public static ExecutionStep dependent(
         int id,
@@ -91,7 +110,9 @@ public record ExecutionStep(
         Map<String, SelectedValue> requirements,
         boolean repeatedExecution
     ) {
-        return new ExecutionStep(id, subgraph, operation, dependsOn, parallelWith, requirements, repeatedExecution, Set.of(), Set.of());
+        Set<String> keyNames = requirements == null ? Set.of() : Set.copyOf(requirements.keySet());
+        return new ExecutionStep(id, subgraph, operation, dependsOn, parallelWith, requirements,
+            repeatedExecution, Set.of(), Set.of(), keyNames, Map.of());
     }
 
     /**
@@ -100,7 +121,7 @@ public record ExecutionStep(
     public boolean hasArtificialFields() {
         return !artificialFieldPaths.isEmpty();
     }
-    
+
     /**
      * Returns a flattened list of all field names in this step.
      * Useful for debugging and simple comparisons.
@@ -112,7 +133,7 @@ public record ExecutionStep(
         }
         return result;
     }
-    
+
     private void flattenSelectionSet(SelectionSet selectionSet, List<String> result) {
         for (Selection<?> selection : selectionSet.getSelections()) {
             if (selection instanceof Field field) {
@@ -121,14 +142,13 @@ public record ExecutionStep(
                     flattenSelectionSet(field.getSelectionSet(), result);
                 }
             } else if (selection instanceof InlineFragment inlineFragment) {
-                // Also flatten fields inside inline fragments
                 if (inlineFragment.getSelectionSet() != null) {
                     flattenSelectionSet(inlineFragment.getSelectionSet(), result);
                 }
             }
         }
     }
-    
+
     /**
      * Generates a GraphQL query string from this step's operation.
      * Uses AstPrinter to properly render the operation including variable definitions.
@@ -136,26 +156,43 @@ public record ExecutionStep(
     public String toGraphQL() {
         return AstPrinter.printAst(operation);
     }
-    
+
     /**
      * Checks if this is a root step (no dependencies).
      */
     public boolean isRoot() {
         return dependsOn.isEmpty();
     }
-    
+
     /**
      * Checks if this step has requirements from previous steps.
      */
     public boolean hasRequirements() {
         return !requirements.isEmpty();
     }
-    
+
     /**
      * Checks if this step can run in parallel with other steps.
      */
     public boolean hasParallelSteps() {
         return !parallelWith.isEmpty();
+    }
+
+    /**
+     * Returns only the requirements that come from {@code @is} lookup keys.
+     */
+    public Map<String, SelectedValue> keyRequirements() {
+        if (keyRequirementNames.isEmpty() || requirements.isEmpty()) {
+            return Map.of();
+        }
+        return requirements.entrySet().stream()
+            .filter(e -> keyRequirementNames.contains(e.getKey()))
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                Map.Entry::getValue,
+                (a, b) -> a,
+                LinkedHashMap::new
+            ));
     }
 
     @Override

--- a/gateway/engine/src/main/java/dev/feddi/federation/engine/planner/OperationPlanner.java
+++ b/gateway/engine/src/main/java/dev/feddi/federation/engine/planner/OperationPlanner.java
@@ -24,6 +24,7 @@ import graphql.language.Argument;
 import graphql.language.Directive;
 import graphql.language.Field;
 import graphql.language.InlineFragment;
+import graphql.language.NonNullType;
 import graphql.language.OperationDefinition;
 import graphql.language.SelectionSet;
 import graphql.language.Type;
@@ -36,6 +37,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -526,7 +528,7 @@ public final class OperationPlanner {
                     for (LookupArgument lookupArg :lookupEdge.lookupArguments()) {
                         Map<String, String> nestedResponseKeys = lookupArgNestedResponseKeys.get(lookupArg.argumentName());
                         SelectedValue requirement = createRequirementSelectedValue(lookupArg, nestedResponseKeys);
-                        lookupTargetPlan.addRequirement(lookupArg.argumentName(), requirement, lookupArg.argumentType());
+                        lookupTargetPlan.addRequirement(lookupArg.argumentName(), requirement, lookupArg.argumentType(), RequirementKind.KEY);
                     }
                 }
 
@@ -598,7 +600,7 @@ public final class OperationPlanner {
                 // Add @require variable as requirement for the target plan
                 SelectedValue transformedSelection = transformSelectionWithResponseKeys(
                     req.selection(), reqResponseKeys);
-                targetPlan.addRequirement(req.argumentName(), transformedSelection, req.argumentType());
+                targetPlan.addRequirement(req.argumentName(), transformedSelection, req.argumentType(), RequirementKind.REQUIRE, req.fieldName(), req.fieldReturnNonNull());
             }
         }
         
@@ -1032,7 +1034,7 @@ public final class OperationPlanner {
                             Map<String, String> nestedResponseKeys = lookupArgNestedResponseKeys.get(lookupArg.argumentName());
                             // Create path with response keys for nested fields like "compositeId.two"
                             Path keyPath = createNestedPath(lookupArg.path(), nestedResponseKeys);
-                            intermediatePlan.addRequirement(lookupArg.argumentName(), new SelectedValue(keyPath), lookupArg.argumentType());
+                            intermediatePlan.addRequirement(lookupArg.argumentName(), new SelectedValue(keyPath), lookupArg.argumentType(), RequirementKind.KEY);
                         }
                     }
 
@@ -1133,7 +1135,7 @@ public final class OperationPlanner {
                 for (LookupArgument lookupArg :lookupEdge.lookupArguments()) {
                     Map<String, String> nestedResponseKeys = lookupArgNestedResponseKeys.get(lookupArg.argumentName());
                     SelectedValue requirement = createRequirementSelectedValue(lookupArg, nestedResponseKeys);
-                    intermediatePlan.addRequirement(lookupArg.argumentName(), requirement, lookupArg.argumentType());
+                    intermediatePlan.addRequirement(lookupArg.argumentName(), requirement, lookupArg.argumentType(), RequirementKind.KEY);
                 }
             }
 
@@ -1168,7 +1170,7 @@ public final class OperationPlanner {
                     // Add the @require variable requirement to intermediate plan
                     SelectedValue transformedSelection = transformSelectionWithResponseKeys(
                         req.selection(), reqResponseKeys);
-                    intermediatePlan.addRequirement(req.argumentName(), transformedSelection, req.argumentType());
+                    intermediatePlan.addRequirement(req.argumentName(), transformedSelection, req.argumentType(), RequirementKind.REQUIRE, req.fieldName(), req.fieldReturnNonNull());
 
                     // Add the field argument for this @require
                     List<String> fieldArgPath = List.of(fieldName);
@@ -1390,7 +1392,7 @@ public final class OperationPlanner {
                     for (LookupArgument lookupArg :enteringLookupEdge.lookupArguments()) {
                         Map<String, String> nestedResponseKeys = lookupArgCombinedResponseKeys.get(lookupArg.argumentName());
                         SelectedValue requirement = createRequirementSelectedValue(lookupArg, nestedResponseKeys);
-                        plan.addRequirement(lookupArg.argumentName(), requirement, lookupArg.argumentType());
+                        plan.addRequirement(lookupArg.argumentName(), requirement, lookupArg.argumentType(), RequirementKind.KEY);
                     }
                 }
             }
@@ -1510,7 +1512,7 @@ public final class OperationPlanner {
                         for (LookupArgument lookupArg :lookupEdge.lookupArguments()) {
                             Map<String, String> nestedResponseKeys = lookupArgCombinedResponseKeys.get(lookupArg.argumentName());
                             SelectedValue requirement = createRequirementSelectedValue(lookupArg, nestedResponseKeys);
-                            lookupTargetPlan.addRequirement(lookupArg.argumentName(), requirement, lookupArg.argumentType());
+                            lookupTargetPlan.addRequirement(lookupArg.argumentName(), requirement, lookupArg.argumentType(), RequirementKind.KEY);
                         }
                     }
 
@@ -1573,7 +1575,7 @@ public final class OperationPlanner {
                             if (req.fieldName() == null || req.fieldName().equals(fieldName)) {
                                 SelectedValue transformedSelection = transformSelectionWithResponseKeys(
                                     req.selection(), reqResponseKeys);
-                                targetPlan.addRequirement(req.argumentName(), transformedSelection, req.argumentType());
+                                targetPlan.addRequirement(req.argumentName(), transformedSelection, req.argumentType(), RequirementKind.REQUIRE, req.fieldName(), req.fieldReturnNonNull());
                             }
                         }
                     }
@@ -1596,10 +1598,22 @@ public final class OperationPlanner {
                     .sorted()
                     .toList();
 
-                // Extract just the SelectedValue from requirements for ExecutionStep
+                // Extract SelectedValue mappings, @is keys, and non-null @require args
                 Map<String, SelectedValue> stepRequirements = new LinkedHashMap<>();
+                Set<String> keyRequirementNames = new LinkedHashSet<>();
+                Map<String, RequireArgumentSkipInfo> nonNullRequireArguments = new LinkedHashMap<>();
                 for (var entry : plan.requirements.entrySet()) {
                     stepRequirements.put(entry.getKey(), entry.getValue().selection());
+                    if (entry.getValue().kind() == RequirementKind.KEY) {
+                        keyRequirementNames.add(entry.getKey());
+                    } else if (entry.getValue().kind() == RequirementKind.REQUIRE
+                        && entry.getValue().type() instanceof NonNullType) {
+                        String fieldName = entry.getValue().fieldName();
+                        if (fieldName != null && !fieldName.isBlank()) {
+                            nonNullRequireArguments.put(entry.getKey(),
+                                new RequireArgumentSkipInfo(fieldName, entry.getValue().fieldReturnNonNull()));
+                        }
+                    }
                 }
 
                 // A step needs repeated execution if it has requirements
@@ -1619,7 +1633,9 @@ public final class OperationPlanner {
                     stepRequirements,
                     repeatedExecution,
                     artificialPaths,
-                    requestedPaths
+                    requestedPaths,
+                    keyRequirementNames,
+                    nonNullRequireArguments
                 );
 
                 steps.add(step);
@@ -1665,7 +1681,9 @@ public final class OperationPlanner {
                     step.requirements(),
                     step.repeatedExecution(),
                     step.artificialFieldPaths(),
-                    step.requestedFieldPaths()
+                    step.requestedFieldPaths(),
+                    step.keyRequirementNames(),
+                    step.nonNullRequireArguments()
                 ));
             }
 
@@ -1725,9 +1743,15 @@ public final class OperationPlanner {
         }
 
         /**
-         * Holds requirement information including the selection and type.
+         * Holds requirement information including the selection, type, kind, and owning field.
          */
-        record RequirementInfo(SelectedValue selection, Type<?> type) {}
+        record RequirementInfo(
+            SelectedValue selection,
+            Type<?> type,
+            RequirementKind kind,
+            String fieldName,
+            boolean fieldReturnNonNull
+        ) {}
         /**
          * Adds an artificial field (for @key or @require) at the specified position.
          * Reuses existing field if already present, or generates unique alias if there's a clash.
@@ -1916,8 +1940,13 @@ public final class OperationPlanner {
             return lastMatch;
         }
 
-        void addRequirement(String name, SelectedValue selection, Type<?> type) {
-            requirements.putIfAbsent(name, new RequirementInfo(selection, type));
+        void addRequirement(String name, SelectedValue selection, Type<?> type, RequirementKind kind) {
+            addRequirement(name, selection, type, kind, null, false);
+        }
+
+        void addRequirement(String name, SelectedValue selection, Type<?> type, RequirementKind kind,
+                            String fieldName, boolean fieldReturnNonNull) {
+            requirements.putIfAbsent(name, new RequirementInfo(selection, type, kind, fieldName, fieldReturnNonNull));
         }
 
         /**

--- a/gateway/engine/src/main/java/dev/feddi/federation/engine/planner/RequireArgumentSkipInfo.java
+++ b/gateway/engine/src/main/java/dev/feddi/federation/engine/planner/RequireArgumentSkipInfo.java
@@ -1,0 +1,15 @@
+package dev.feddi.federation.engine.planner;
+
+/**
+ * Metadata for a non-null {@code @require} argument used when the resolved value is null.
+ *
+ * @param fieldName the field that owns the {@code @require} argument
+ * @param fieldReturnNonNull true when that field's return type is non-null (Case 3 → emit error)
+ */
+public record RequireArgumentSkipInfo(String fieldName, boolean fieldReturnNonNull) {
+    public RequireArgumentSkipInfo {
+        if (fieldName == null || fieldName.isBlank()) {
+            throw new IllegalArgumentException("fieldName cannot be null or blank");
+        }
+    }
+}

--- a/gateway/engine/src/main/java/dev/feddi/federation/engine/planner/RequirementKind.java
+++ b/gateway/engine/src/main/java/dev/feddi/federation/engine/planner/RequirementKind.java
@@ -1,0 +1,16 @@
+package dev.feddi.federation.engine.planner;
+
+/**
+ * Distinguishes how an execution-step requirement was introduced.
+ *
+ * <ul>
+ *   <li>{@link #KEY} — from a {@code @lookup} argument {@code @is} mapping; null keys
+ *       mean the entity cannot be resolved and the subgraph call is skipped.</li>
+ *   <li>{@link #REQUIRE} — from a field argument {@code @require}; null handling
+ *       depends on argument (and later field-return) nullability.</li>
+ * </ul>
+ */
+public enum RequirementKind {
+    KEY,
+    REQUIRE
+}

--- a/gateway/engine/src/test/java/dev/feddi/federation/engine/plan/ExecutionStepGraphQLGenerationTest.java
+++ b/gateway/engine/src/test/java/dev/feddi/federation/engine/plan/ExecutionStepGraphQLGenerationTest.java
@@ -119,7 +119,9 @@ class ExecutionStepGraphQLGenerationTest {
             Map.of(),
             false,
             Set.of(),
-            Set.of()
+            Set.of(),
+            Set.of(),
+            Map.of()
         );
         
         // Generate GraphQL
@@ -202,7 +204,9 @@ class ExecutionStepGraphQLGenerationTest {
             Map.of(),
             false,
             Set.of(),
-            Set.of()
+            Set.of(),
+            Set.of(),
+            Map.of()
         );
         
         // Verify operation is accessible

--- a/gateway/engine/src/test/java/dev/feddi/federation/engine/testcase/TestCaseLoader.java
+++ b/gateway/engine/src/test/java/dev/feddi/federation/engine/testcase/TestCaseLoader.java
@@ -392,7 +392,9 @@ public final class TestCaseLoader {
                         step.requirements(),
                         step.repeatedExecution(),
                         Set.of(),
-                        Set.of()
+                        Set.of(),
+                        step.keyRequirementNames(),
+                        step.nonNullRequireArguments()
                     ));
                 }
             } else {
@@ -441,7 +443,12 @@ public final class TestCaseLoader {
             repeatedExecution = !requirements.isEmpty();
         }
 
-        return new ExecutionStep(id, subgraph, operation, dependsOn, parallelWith, requirements, repeatedExecution, Set.of(), Set.of());
+        // Planning YAML fixtures do not distinguish @is vs @require; treat all as keys
+        // so executor skip behavior stays conservative for hand-written plans.
+        Set<String> keyRequirementNames = Set.copyOf(requirements.keySet());
+
+        return new ExecutionStep(id, subgraph, operation, dependsOn, parallelWith, requirements,
+            repeatedExecution, Set.of(), Set.of(), keyRequirementNames, Map.of());
     }
     
     /**

--- a/gateway/engine/src/test/resources/schemas/require_nullability/executions/01_nullable_arg_with_null.yaml
+++ b/gateway/engine/src/test/resources/schemas/require_nullability/executions/01_nullable_arg_with_null.yaml
@@ -1,7 +1,5 @@
 name: "Nullable argument receives null value - calls subgraph"
 description: |
-  NOT YET IMPLEMENTED - This test documents expected future behavior.
-
   When a @require argument has a nullable type (Float) and the value is null,
   the subgraph should be called with the null value. This allows the subgraph
   to decide how to handle null input values.
@@ -10,8 +8,6 @@ description: |
   - Argument type: nullable (Float)
   - Value: null
   - Behavior: Call subgraph with null
-
-skip: true
 
 query: |
   {

--- a/gateway/engine/src/test/resources/schemas/require_nullability/executions/02_nonnull_arg_nullable_field.yaml
+++ b/gateway/engine/src/test/resources/schemas/require_nullability/executions/02_nonnull_arg_nullable_field.yaml
@@ -1,7 +1,5 @@
 name: "Non-null argument with null value, nullable field - returns null"
 description: |
-  NOT YET IMPLEMENTED - This test documents expected future behavior.
-
   When a @require argument has a non-null type (Float!) but the value is null,
   and the field's return type is nullable (Float), the subgraph call should
   be skipped and the field should return null without an error.
@@ -11,8 +9,6 @@ description: |
   - Value: null
   - Field return type: nullable (Float)
   - Behavior: Skip call, return null, no error
-
-skip: true
 
 query: |
   {

--- a/gateway/engine/src/test/resources/schemas/require_nullability/executions/03_nonnull_arg_nonnull_field.yaml
+++ b/gateway/engine/src/test/resources/schemas/require_nullability/executions/03_nonnull_arg_nonnull_field.yaml
@@ -1,7 +1,5 @@
 name: "Non-null argument with null value, non-null field - error"
 description: |
-  NOT YET IMPLEMENTED - This test documents expected future behavior.
-
   When a @require argument has a non-null type (Float!) but the value is null,
   and the field's return type is also non-null (Float!), the subgraph call should
   be skipped, the field should be null, and an error should be added to the response.
@@ -11,8 +9,6 @@ description: |
   - Value: null
   - Field return type: non-null (Float!)
   - Behavior: Skip call, return null, add error
-
-skip: true
 
 query: |
   {

--- a/gateway/engine/src/test/resources/schemas/require_nullability/executions/04_nonnull_arg_has_value.yaml
+++ b/gateway/engine/src/test/resources/schemas/require_nullability/executions/04_nonnull_arg_has_value.yaml
@@ -1,13 +1,9 @@
 name: "Non-null argument with valid value - calls subgraph"
 description: |
-  NOT YET IMPLEMENTED - This test documents expected future behavior.
-
   When a @require argument has a non-null type (Float!) and the value is present,
   the subgraph should be called normally with the value.
 
   This is the happy path where the required value is available.
-
-skip: true
 
 query: |
   {

--- a/gateway/engine/src/test/resources/schemas/require_nullability/schema.yaml
+++ b/gateway/engine/src/test/resources/schemas/require_nullability/schema.yaml
@@ -1,17 +1,16 @@
 name: "Require Nullability Tests"
 description: |
-  NOT YET IMPLEMENTED - These tests document expected future behavior for @require argument nullability.
-
   Tests @require argument nullability behavior based on type definitions:
-  - Case 1: Nullable argument with null value -> Call subgraph with null
-  - Case 2: Non-null argument with null value, nullable field -> Skip call, return null
-  - Case 3: Non-null argument with null value, non-null field -> Skip call, return null, add error
+  - Case 1: Nullable argument with null value -> Call subgraph with null (IMPLEMENTED)
+  - Case 2: Non-null argument with null value, nullable field -> Skip call, return null (IMPLEMENTED)
+  - Case 3: Non-null argument with null value, non-null field -> Skip call, return null, add error (IMPLEMENTED)
+  - Case 4: Non-null argument with valid value -> Call subgraph normally (IMPLEMENTED)
 
-  Implementation requires:
-  1. Tracking which requirements are key fields (@is/@key) vs @require fields
-  2. Only enforcing non-null constraint on @require fields, not all requirements
-  3. Adding field return type information to ExecutionStep
-  4. Implementing nullability-aware skip logic in Executor
+  Implementation status:
+  1. Tracking which requirements are key fields (@is) vs @require fields — done
+  2. Enforcing non-null constraint only on non-null @require args — done
+  3. Field return type on @require metadata for Case 3 errors — done
+  4. Nullability-aware skip/call/error logic in Executor — Cases 1–4 done
 
 subgraphs:
   products: |


### PR DESCRIPTION
## Summary
- Implements `@require` argument nullability (Cases 1–4 from the `require_nullability` fixtures).
- Distinguishes `@is` key requirements from `@require` args in planning/execution.
- Nullable `@require` + null → call subgraph with null; non-null `@require` + null → skip (emit `REQUIRED_ARGUMENT_NULL` when the field return type is also non-null).

## Test plan
- [x] `:engine:test` — **1108 passed, 0 failed, 0 skipped**
- [x] Unskipped and verified all four fixtures under `schemas/require_nullability/executions/`:
  - `01_nullable_arg_with_null`
  - `02_nonnull_arg_nullable_field`
  - `03_nonnull_arg_nonnull_field`
  - `04_nonnull_arg_has_value`
- [x] Confirmed no regression on `benchmark_heavy_query` nested null lookup